### PR TITLE
Optimise drawing of particles

### DIFF
--- a/algorithms/src/Area.cpp
+++ b/algorithms/src/Area.cpp
@@ -6,16 +6,14 @@
 
 #include "Area.h"
 
-namespace SPHAlgorithms
+namespace SPHSDK
 {
-
-// TODO: implement
 
 Area::Area() : m_boundingRect(Rect())
 {
 }
 
-double Area::areaFunction(double /*x*/, double /*y*/)
+FLOAT Area::areaFunction(FLOAT /*x*/, FLOAT /*y*/)
 {
   return 0.;
 }
@@ -29,7 +27,7 @@ Rect Area::getBoundingRect() const
     return m_boundingRect;
 }
 
-bool Area::isInsideArea(const Point2D& /*point*/)
+bool Area::isInsideArea(const Point2F& /*point*/)
 {
     return false;
 }
@@ -45,4 +43,4 @@ Cuboid Volume::getBoundingCuboid() const
     return m_boundingCuboid;
 }
 
-} //SPHAlgorithms
+} // SPHSDK

--- a/algorithms/src/Area.h
+++ b/algorithms/src/Area.h
@@ -9,21 +9,20 @@
 
 #include "Point.h"
 
-namespace SPHAlgorithms
+namespace SPHSDK
 {
 
-// TODO move to common and to separate class
 struct Rect
 {
-    Point2D leftTop;
+    Point2F leftTop;
 
-    Point2D rightBottom;
+    Point2F rightBottom;
 
     Rect() :
-        leftTop(Point2D()),
-        rightBottom(Point2D()) {}
+        leftTop(Point2F()),
+        rightBottom(Point2F()) {}
 
-    Rect(const Point2D& leftTop_, const Point2D& rightBotom_) :
+    Rect(const Point2F& leftTop_, const Point2F& rightBotom_) :
         leftTop(leftTop_),
         rightBottom(rightBotom_) {}
 };
@@ -34,7 +33,7 @@ struct Rect
 struct Cuboid
 {
     Point3F startingPoint;
-    double width, length, height; // x, y, z axis
+    FLOAT width, length, height; // x, y, z axis
 
     Cuboid() :
         startingPoint(Point3F()),
@@ -42,7 +41,7 @@ struct Cuboid
         length(0.),
         height(0.) {}
 
-    Cuboid(const Point3F& _startingPoint, const double _width, const double _length, const double _height) :
+    Cuboid(const Point3F& _startingPoint, const FLOAT _width, const FLOAT _length, const FLOAT _height) :
         startingPoint(_startingPoint),
         width(_width),
         length(_length),
@@ -62,11 +61,11 @@ public:
 
     ~Area() = default;
 
-    double areaFunction(double x, double y);
+    FLOAT areaFunction(FLOAT x, FLOAT y);
 
     Rect getBoundingRect() const;
 
-    bool isInsideArea(const Point2D& point);
+    bool isInsideArea(const Point2F& point);
 
 private:
 
@@ -97,6 +96,6 @@ private:
 
 };
 
-} //SPHAlgorithms
+} // SPHSDK
 
 #endif // AREA_H_43C34465A6ED4DB9B9F2F4C3937BF5DC

--- a/algorithms/src/Area.h
+++ b/algorithms/src/Area.h
@@ -33,16 +33,16 @@ struct Rect
 */
 struct Cuboid
 {
-    Point3D startingPoint;
+    Point3F startingPoint;
     double width, length, height; // x, y, z axis
 
     Cuboid() :
-        startingPoint(Point3D()),
+        startingPoint(Point3F()),
         width(0.),
         length(0.),
         height(0.) {}
 
-    Cuboid(const Point3D& _startingPoint, const double _width, const double _length, const double _height) :
+    Cuboid(const Point3F& _startingPoint, const double _width, const double _length, const double _height) :
         startingPoint(_startingPoint),
         width(_width),
         length(_length),

--- a/algorithms/src/Defines.h
+++ b/algorithms/src/Defines.h
@@ -9,15 +9,17 @@
 
 #include <vector>
 #include <cstddef>
+#include <cfloat>
 
-//TODO: move to common
-
-namespace SPHAlgorithms
+namespace SPHSDK
 {
+    // Float precision to be used in all algorithims
+    using FLOAT = float;
+
     using SizetVector = std::vector<size_t>;
 
     using VectorOfSizetVectors = std::vector<SizetVector>;
 
-} //SPHAlgorithms
+} // SPHSDK
 
 #endif // DEFINES_H_B25DE75875BB40248241AD0DFE5A69FC

--- a/algorithms/src/Defines.h
+++ b/algorithms/src/Defines.h
@@ -14,7 +14,7 @@
 namespace SPHSDK
 {
     // Float precision to be used in all algorithims
-    using FLOAT = float;
+    using FLOAT = double;
 
     using SizetVector = std::vector<size_t>;
 

--- a/algorithms/src/MarchingCubes.cpp
+++ b/algorithms/src/MarchingCubes.cpp
@@ -7,18 +7,18 @@
 #include "MarchingCubes.h"
 #include "MarchingCubesConfig.h"
 
-namespace SPHAlgorithms
+namespace SPHSDK
 {
 
-Point3FVector MarchingCubes::generateMesh(std::function<float(float, float, float)> f)
+Point3FVector MarchingCubes::generateMesh(std::function<FLOAT(FLOAT, FLOAT, FLOAT)> f)
 {
     Point3FVector mesh;
 
-    for (float x = X_MIN; x < X_MAX; x += GRID_CUBE_SIZE)
+    for (auto x = X_MIN; x < X_MAX; x += GRID_CUBE_SIZE)
     {
-        for (float y = Y_MIN; y < Y_MAX; y += GRID_CUBE_SIZE)
+        for (auto y = Y_MIN; y < Y_MAX; y += GRID_CUBE_SIZE)
         {
-            for (float z = Z_MIN; z < Z_MAX; z += GRID_CUBE_SIZE)
+            for (auto z = Z_MIN; z < Z_MAX; z += GRID_CUBE_SIZE)
             {
                 // iX, iY, iZ are coordinates of the current vertex in grid_cube
                 const auto vertices = MarchingCube(f, x, y, z);
@@ -29,24 +29,24 @@ Point3FVector MarchingCubes::generateMesh(std::function<float(float, float, floa
     return mesh;
 }
 
-static float adapt(float a, float b)
+static FLOAT adapt(FLOAT a, FLOAT b)
 {
-    const float delta = b - a;
+    const auto delta = b - a;
 
-    if (std::abs(delta) < PRECISION)
+    if (std::abs(delta) < MC_PRECISION)
     {
-        return 0.5f;
+        return static_cast<FLOAT>(0.5);
     }
 
     return -a / delta;
 }
 
-Point3FVector MarchingCubes::MarchingCube(std::function<float(float, float, float)> f, float fX, float fY, float fZ)
+Point3FVector MarchingCubes::MarchingCube(std::function<FLOAT(FLOAT, FLOAT, FLOAT)> f, FLOAT fX, FLOAT fY, FLOAT fZ)
 {
     // vector with all triangles found
     Point3FVector trianglesMesh;
 
-    float CubeValue[CUBE_VERTICES_NUMBER];
+    FLOAT CubeValue[CUBE_VERTICES_NUMBER];
 
     // Evaluate value of the cube vertex at each point
     for (int iVertex = 0; iVertex < CUBE_VERTICES_NUMBER; iVertex++)
@@ -75,7 +75,7 @@ Point3FVector MarchingCubes::MarchingCube(std::function<float(float, float, floa
 
 void MarchingCubes::fillFoundTriangles(Point3FVector&       resultEdgeVertex,
                                        const Point3FVector& EdgeVertex,
-                                       const int            iFlagIndex)
+                                       const int           iFlagIndex)
 {
     for (int iTriangle = 0; iTriangle < TRIANGLES_MAX_NUMBER_FOR_ONE_CUBE; iTriangle++)
     {
@@ -87,14 +87,14 @@ void MarchingCubes::fillFoundTriangles(Point3FVector&       resultEdgeVertex,
         for (int iCorner = 0; iCorner < TRIANGLES_CORNERS_NUMBER; iCorner++)
         {
             const int iVertex = TriangleConnectionTable[iFlagIndex][TRIANGLES_CORNERS_NUMBER * iTriangle + iCorner];
-            resultEdgeVertex.push_back(Point3F(EdgeVertex[iVertex].x, EdgeVertex[iVertex].y, EdgeVertex[iVertex].z));
+            resultEdgeVertex.push_back(Point3(EdgeVertex[iVertex].x, EdgeVertex[iVertex].y, EdgeVertex[iVertex].z));
         }
     }
 }
 
 // Find points of intersection on each edge
 Point3FVector MarchingCubes::findPointIntersection(
-    const int iEdgeFlags, const float CubeValue[], const float fX, const float fY, const float fZ)
+    const int iEdgeFlags, const FLOAT CubeValue[], const FLOAT fX, const FLOAT fY, const FLOAT fZ)
 {
     Point3FVector EdgeVertex(12);
 
@@ -104,14 +104,14 @@ Point3FVector MarchingCubes::findPointIntersection(
         if (iEdgeFlags & (1 << iEdge))
         {
             // Find the two vertices specified by this edge, and interpolate them according to adapt
-            const int v0 = EdgeConnection[iEdge][0];
-            const int v1 = EdgeConnection[iEdge][1];
+            const auto v0 = EdgeConnection[iEdge][0];
+            const auto v1 = EdgeConnection[iEdge][1];
 
-            const float f0 = CubeValue[v0];
-            const float f1 = CubeValue[v1];
+            const auto f0 = CubeValue[v0];
+            const auto f1 = CubeValue[v1];
 
-            const float t0 = 1.f - adapt(f0, f1);
-            const float t1 = 1.f - t0;
+            const auto t0 = 1 - adapt(f0, f1);
+            const auto t1 = 1 - t0;
 
             EdgeVertex[iEdge].x = fX + VertexOffset[v0][0] * t0 + VertexOffset[v1][0] * t1;
             EdgeVertex[iEdge].y = fY + VertexOffset[v0][1] * t0 + VertexOffset[v1][1] * t1;
@@ -120,7 +120,7 @@ Point3FVector MarchingCubes::findPointIntersection(
     }
     return EdgeVertex;
 }
-int MarchingCubes::determineFlag(const float CubeValue[])
+int MarchingCubes::determineFlag(const FLOAT CubeValue[])
 {
     int flagIndex = 0;
 
@@ -133,4 +133,4 @@ int MarchingCubes::determineFlag(const float CubeValue[])
     }
     return flagIndex;
 }
-} // namespace SPHAlgorithms
+} // namespace SPHSDK

--- a/algorithms/src/MarchingCubes.h
+++ b/algorithms/src/MarchingCubes.h
@@ -11,7 +11,7 @@
 
 #include <functional>
 
-namespace SPHAlgorithms
+namespace SPHSDK
 {
 
 /**
@@ -25,20 +25,20 @@ public:
      * @brief Generates triangles mesh from function
      * @param f    The function that represents the domain equation
      */
-    static Point3FVector generateMesh(std::function<float(float, float, float)> f);
+    static Point3FVector generateMesh(std::function<FLOAT(FLOAT, FLOAT, FLOAT)> f);
 
 private:
-    static Point3FVector MarchingCube(std::function<float(float, float, float)> f, float fX, float fY, float fZ);
+    static Point3FVector MarchingCube(std::function<FLOAT(FLOAT, FLOAT, FLOAT)> f, FLOAT fX, FLOAT fY, FLOAT fZ);
 
     static void
     fillFoundTriangles(Point3FVector& resultEdgeVertex, const Point3FVector& EdgeVertex, const int iFlagIndex);
 
     static Point3FVector findPointIntersection(
-        const int iEdgeFlags, const float CubeValue[], const float fX, const float fY, const float fZ);
+        const int iEdgeFlags, const FLOAT CubeValue[], const FLOAT fX, const FLOAT fY, const FLOAT fZ);
 
-    static int determineFlag(const float CubeValue[]);
+    static int determineFlag(const FLOAT CubeValue[]);
 };
 
-} // namespace SPHAlgorithms
+} // namespace SPHSDK
 
 #endif // MARCHING_CUBES_H_43C34465A6ED4DB9B9F2F4C3937BF5DC

--- a/algorithms/src/MarchingCubesConfig.h
+++ b/algorithms/src/MarchingCubesConfig.h
@@ -7,25 +7,25 @@
 #ifndef MARCHING_CUBES_CONFIG_H_43C34465A6ED4DB9B9F2F4C3937BF5DC
 #define MARCHING_CUBES_CONFIG_H_43C34465A6ED4DB9B9F2F4C3937BF5DC
 
-namespace SPHAlgorithms
+namespace SPHSDK
 {
 
 // The size of the domain
-constexpr float CUBE_SIZE = 3.0f;
+constexpr FLOAT CUBE_SIZE = 3.0f;
 
 // Number of the grid cubes by which the domain is splitted
 constexpr int GRID_CUBES_NUMBER = 100;
 
 // Size of the grid cube
-const constexpr float GRID_CUBE_SIZE = CUBE_SIZE / GRID_CUBES_NUMBER;
+const constexpr FLOAT GRID_CUBE_SIZE = CUBE_SIZE / GRID_CUBES_NUMBER;
 
 // The dimensions of the grid [X_MIN, X_MAX] x [Y_MIN, Y_MAX] x [Z_MIN, Z_MAX]
-constexpr float X_MIN = 0.f;
-constexpr float X_MAX = CUBE_SIZE;
-constexpr float Y_MIN = 0.f;
-constexpr float Y_MAX = CUBE_SIZE;
-constexpr float Z_MIN = 0.f;
-constexpr float Z_MAX = CUBE_SIZE;
+constexpr FLOAT X_MIN = 0.f;
+constexpr FLOAT X_MAX = CUBE_SIZE;
+constexpr FLOAT Y_MIN = 0.f;
+constexpr FLOAT Y_MAX = CUBE_SIZE;
+constexpr FLOAT Z_MIN = 0.f;
+constexpr FLOAT Z_MAX = CUBE_SIZE;
 
 constexpr int CUBE_VERTICES_NUMBER = 8;
 constexpr int CUBE_DIMENSION = 3;
@@ -34,10 +34,10 @@ constexpr int TRIANGLES_MAX_NUMBER_FOR_ONE_CUBE = 5;
 constexpr int TRIANGLES_CORNERS_NUMBER = 3;
 
 // given precision
-constexpr float PRECISION = 0.0001f;
+constexpr FLOAT MC_PRECISION = 0.0001f;
 
 // VertexOffset lists the positions, for each grid cube in the grid
-constexpr float VertexOffset[CUBE_VERTICES_NUMBER][CUBE_DIMENSION] = {{0.0, 0.0, 0.0},
+constexpr FLOAT VertexOffset[CUBE_VERTICES_NUMBER][CUBE_DIMENSION] = {{0.0, 0.0, 0.0},
                                                                       {GRID_CUBE_SIZE, 0.0, 0.0},
                                                                       {GRID_CUBE_SIZE, GRID_CUBE_SIZE, 0.0},
                                                                       {0.0, GRID_CUBE_SIZE, 0.0},
@@ -329,6 +329,6 @@ constexpr int TriangleConnectionTable[NUMBER_OF_CASES][16] = {
     {0, 9, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1},
     {0, 3, 8, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1},
     {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1}};
-} // namespace SPHAlgorithms
+} // namespace SPHSDK
 
 #endif // MARCHING_CUBES_CONFIG_H_43C34465A6ED4DB9B9F2F4C3937BF5DC

--- a/algorithms/src/NeighboursSearch.h
+++ b/algorithms/src/NeighboursSearch.h
@@ -11,7 +11,7 @@
 #include "Defines.h"
 #include "Area.h"
 
-namespace SPHAlgorithms
+namespace SPHSDK
 {
 
 namespace TestEnvironment
@@ -34,7 +34,7 @@ class NeighboursSearch
 
 public:
 
-    explicit NeighboursSearch(const Area& area, double radius, double eps);
+    explicit NeighboursSearch(const Area& area, FLOAT radius, FLOAT eps);
 
     ~NeighboursSearch();
 
@@ -50,9 +50,9 @@ private:
 
     Area m_Area;
 
-    double m_radius;
+    FLOAT m_radius;
 
-    double m_eps;
+    FLOAT m_eps;
 
     VectorOfSizetVectors m_boxes;
 
@@ -62,9 +62,9 @@ private:
 
     size_t m_pointsSize; // the amount of points
 
-    double m_rectWidth;
+    FLOAT m_rectWidth;
 
-    double m_rectHeight;
+    FLOAT m_rectHeight;
 };
 
 // ---------------------------
@@ -75,7 +75,7 @@ template <class T> class NeighboursSearch3D
     
 public:
 
-    explicit NeighboursSearch3D(const Volume& volume, double radius, double eps);
+    explicit NeighboursSearch3D(const Volume& volume, FLOAT radius, FLOAT eps);
 
     ~NeighboursSearch3D();
 
@@ -134,9 +134,9 @@ private:
 
     Volume m_volume;
 
-    double m_radius;
+    FLOAT m_radius;
 
-    double m_eps;
+    FLOAT m_eps;
 
     VectorOfSizetVectors m_boxes;
 
@@ -152,7 +152,7 @@ private:
     size_t m_normalizedCuboidLength;
     size_t m_normalizedCuboidHeight;
 };
-} //SPHAlgorithms
+} // namespace SPHSDK
 
 #include "NeighboursSearch.hpp"
 

--- a/algorithms/src/NeighboursSearch.hpp
+++ b/algorithms/src/NeighboursSearch.hpp
@@ -253,7 +253,7 @@ template <class T> void NeighboursSearch3D<T>::search(T& points)
             for (size_t nearbyPointIndex = 0; nearbyPointIndex < m_boxes[boxIndex].size(); nearbyPointIndex++)
                 if (pointIndex != nearbyPointIndex)
                 {
-                    Point3D difference = points[m_boxes[boxIndex][pointIndex]].position -
+                    Point3F difference = points[m_boxes[boxIndex][pointIndex]].position -
                                          points[m_boxes[boxIndex][nearbyPointIndex]].position;
                     if (difference.calcNormSqr() <= pow(m_radius, 2))
                         points[m_boxes[boxIndex][pointIndex]].neighbours.push_back(m_boxes[boxIndex][nearbyPointIndex]);
@@ -264,7 +264,7 @@ template <class T> void NeighboursSearch3D<T>::search(T& points)
             for (size_t nearbyBoxIndex = 0; nearbyBoxIndex < m_nearbyBoxes[boxIndex].size(); nearbyBoxIndex++)
                 for (size_t nearbyPointIndex = 0; nearbyPointIndex < m_boxes[m_nearbyBoxes[boxIndex][nearbyBoxIndex]].size(); nearbyPointIndex++)
                 {
-                    Point3D difference = points[m_boxes[boxIndex][pointIndex]].position -
+                    Point3F difference = points[m_boxes[boxIndex][pointIndex]].position -
                                          points[m_boxes[m_nearbyBoxes[boxIndex][nearbyBoxIndex]][nearbyPointIndex]].position;
                     if (difference.calcNormSqr() - pow(m_radius, 2) <= DBL_EPSILON)
                         points[m_boxes[boxIndex][pointIndex]]

--- a/algorithms/src/NeighboursSearch.hpp
+++ b/algorithms/src/NeighboursSearch.hpp
@@ -13,11 +13,11 @@
 #include <cmath>
 
 
-namespace SPHAlgorithms
+namespace SPHSDK
 {
 
 template <class T>
-NeighboursSearch<T>::NeighboursSearch(const Area& area, double radius, double eps)
+NeighboursSearch<T>::NeighboursSearch(const Area& area, FLOAT radius, FLOAT eps)
     : m_Area(area)
     , m_radius(radius)
     , m_eps(eps)
@@ -70,8 +70,8 @@ template <class T> void NeighboursSearch<T>::search(T& points)
             {
                 if (j != k)
                 {
-                    double distanceSqr = pow(points[m_boxes[i][j]].position.x - points[m_boxes[i][k]].position.x, 2) +
-                                         pow(points[m_boxes[i][j]].position.y - points[m_boxes[i][k]].position.y, 2);
+                    const FLOAT distanceSqr = pow(points[m_boxes[i][j]].position.x - points[m_boxes[i][k]].position.x, 2) +
+                                              pow(points[m_boxes[i][j]].position.y - points[m_boxes[i][k]].position.y, 2);
                     if (distanceSqr <= pow(m_radius, 2))
                         points[m_boxes[i][j]].neighbours.push_back(m_boxes[i][k]);
                 }
@@ -88,7 +88,7 @@ template <class T> void NeighboursSearch<T>::search(T& points)
             {
                 for (size_t q = 0; q < m_boxes[m_nearbyBoxes[i][k]].size(); q++)
                 {
-                    double distanceSqr =
+                    const FLOAT distanceSqr =
                         pow(points[m_boxes[i][j]].position.x - points[m_boxes[m_nearbyBoxes[i][k]][q]].position.x, 2) +
                         pow(points[m_boxes[i][j]].position.y - points[m_boxes[m_nearbyBoxes[i][k]][q]].position.y, 2);
                     if (distanceSqr - pow(m_radius, 2) <= DBL_EPSILON)
@@ -208,7 +208,7 @@ template <class T> void NeighboursSearch<T>::findNearbyBoxes()
 // ---------------------------
 
 template <class T>
-NeighboursSearch3D<T>::NeighboursSearch3D(const Volume& volume, double radius, double eps)
+NeighboursSearch3D<T>::NeighboursSearch3D(const Volume& volume, FLOAT radius, FLOAT eps)
     : m_volume(volume)
     , m_radius(radius)
     , m_eps(eps)
@@ -693,4 +693,4 @@ template <class T> void NeighboursSearch3D<T>:: addForMiddle(const size_t boxInd
     }
 }
 
-} // namespace SPHAlgorithms
+} // namespace SPHSDK

--- a/algorithms/src/Point.h
+++ b/algorithms/src/Point.h
@@ -7,9 +7,11 @@
 #ifndef POINT_H_DE836BDF10964E14A5C9BA80FEDE6734
 #define POINT_H_DE836BDF10964E14A5C9BA80FEDE6734
 
+#include "Defines.h"
+
 #include <vector>
 
-namespace SPHAlgorithms
+namespace SPHSDK
 {
 
 /**
@@ -32,13 +34,9 @@ public:
     _Tp x, y; //< the point coordinates
 };
 
-using Point2D = Point2<double>;
-using Point2F = Point2<float>;
-using Point2I = Point2<int>;
+using Point2F = Point2<FLOAT>;
 
-using Point2DVector = std::vector<Point2D>;
 using Point2FVector = std::vector<Point2F>;
-using Point2IVector = std::vector<Point2I>;
 
 /**
  * @brief Point3 class defines point in 3D.
@@ -61,13 +59,11 @@ public:
     _Tp x, y, z; //< the point coordinates
 };
 
-using Point3D = Point3<double>;
-using Point3F = Point3<float>;
+using Point3F = Point3<FLOAT>;
 
-using Point3DVector = std::vector<Point3D>;
 using Point3FVector = std::vector<Point3F>;
 
-} // namespace SPHAlgorithms
+} // namespace SPHSDK
 
 #include "Point.hpp"
 

--- a/algorithms/src/Point.hpp
+++ b/algorithms/src/Point.hpp
@@ -10,7 +10,7 @@
 #include "Point.h"
 #include <cmath>
 
-namespace SPHAlgorithms
+namespace SPHSDK
 {
 
 template <typename _Tp>
@@ -62,7 +62,7 @@ template <typename _Tp> static inline bool operator!=(const Point2<_Tp>& a, cons
     return a.x != b.x || a.y != b.y;
 }
 
-template <typename _Tp> static inline Point2<_Tp> operator*=(Point2<_Tp>& a, const double b)
+template <typename _Tp> static inline Point2<_Tp> operator*=(Point2<_Tp>& a, const FLOAT b)
 {
     a.x *= b;
     a.y *= b;
@@ -91,12 +91,12 @@ template <typename _Tp> static inline Point2<_Tp> operator-(const Point2<_Tp>& a
     return Point2<_Tp>(static_cast<_Tp>(-a.x), static_cast<_Tp>(-a.y));
 }
 
-template <typename _Tp> static inline Point2<_Tp> operator/(const Point2<_Tp>& a, const double b)
+template <typename _Tp> static inline Point2<_Tp> operator/(const Point2<_Tp>& a, const FLOAT b)
 {
     return Point2<_Tp>(static_cast<_Tp>(a.x / b), static_cast<_Tp>(a.y / b));
 }
 
-template <typename _Tp> static inline Point2<_Tp> operator*(const Point2<_Tp>& a, const double b)
+template <typename _Tp> static inline Point2<_Tp> operator*(const Point2<_Tp>& a, const FLOAT b)
 {
     return Point2<_Tp>(static_cast<_Tp>(a.x * b), static_cast<_Tp>(a.y * b));
 }
@@ -156,7 +156,7 @@ template <typename _Tp> inline bool operator!=(const Point3<_Tp>& a, const Point
     return a.x != b.x || a.y != b.y || a.z != b.z;
 }
 
-template <typename _Tp> inline Point3<_Tp> operator*=(Point3<_Tp>& a, const double b)
+template <typename _Tp> inline Point3<_Tp> operator*=(Point3<_Tp>& a, const FLOAT b)
 {
     a.x *= b;
     a.y *= b;
@@ -189,25 +189,25 @@ template <typename _Tp> inline Point3<_Tp> operator-(const Point3<_Tp>& a)
     return Point3<_Tp>(-a.x, -a.y, -a.z);
 }
 
-template <typename _Tp> inline Point3<_Tp> operator/(const Point3<_Tp> a, const double b)
+template <typename _Tp> inline Point3<_Tp> operator/(const Point3<_Tp> a, const FLOAT b)
 {
     return Point3<_Tp>(a.x / b, a.y / b, a.z / b);
 }
 
-template <typename _Tp> inline Point3<_Tp> operator/(const double b, const Point3<_Tp> a)
+template <typename _Tp> inline Point3<_Tp> operator/(const FLOAT b, const Point3<_Tp> a)
 {
     return Point3<_Tp>(b / a.x, b / a.y, b / a.z);
 }
 
-template <typename _Tp> inline Point3<_Tp> operator*(const Point3<_Tp>& a, const double b)
+template <typename _Tp> inline Point3<_Tp> operator*(const Point3<_Tp>& a, const FLOAT b)
 {
     return Point3<_Tp>(a.x * b, a.y * b, a.z * b);
 }
 
-template <typename _Tp> inline Point3<_Tp> operator*(const double b, const Point3<_Tp>& a)
+template <typename _Tp> inline Point3<_Tp> operator*(const FLOAT b, const Point3<_Tp>& a)
 {
     return Point3<_Tp>(b * a.x, b * a.y, b * a.z);
 }
-} // namespace SPHAlgorithms
+} // namespace SPHSDK
 
 #endif // POINT_HPP_FCE0209B335F4EBB846046447678D096

--- a/algorithms/src/ROperations.h
+++ b/algorithms/src/ROperations.h
@@ -7,7 +7,7 @@
 #ifndef R_OPERATIONS_H_43C34465A6ED4DB9B9F2F4C3937BF5DD
 #define R_OPERATIONS_H_43C34465A6ED4DB9B9F2F4C3937BF5DD
 
-namespace SPHAlgorithms
+namespace SPHSDK
 {
 
 /**
@@ -33,7 +33,7 @@ public:
     template <class T> static T disjunction(T x, T y);
 };
 
-} // namespace SPHAlgorithms
+} // namespace SPHSDK
 
 #include "ROperations.hpp"
 

--- a/algorithms/src/ROperations.hpp
+++ b/algorithms/src/ROperations.hpp
@@ -7,7 +7,7 @@
 #include <cassert>
 #include <cmath>
 
-namespace SPHAlgorithms
+namespace SPHSDK
 {
 
 template <class T> T ROperations::conjunction(T x, T y)
@@ -20,4 +20,4 @@ template <class T> T ROperations::disjunction(T x, T y)
     return x + y + std::sqrt(x * x + y * y);
 }
 
-} // namespace SPHAlgorithms
+} // namespace SPHSDK

--- a/algorithms/src/Shapes.h
+++ b/algorithms/src/Shapes.h
@@ -9,7 +9,7 @@
 
 #include "ROperations.h"
 
-namespace SPHAlgorithms
+namespace SPHSDK
 {
 
 /**
@@ -18,8 +18,8 @@ namespace SPHAlgorithms
 class Shapes
 {
 private:
-    static constexpr auto dis = ROperations::disjunction<float>;
-    static constexpr auto con = ROperations::conjunction<float>;
+    static constexpr auto dis = ROperations::disjunction<FLOAT>;
+    static constexpr auto con = ROperations::conjunction<FLOAT>;
 
 public:
     /**
@@ -29,13 +29,13 @@ public:
      * @param z    The z-coordinate.
      * @return a value that > 0 inside the object, = 0 on the border and < 0 outside.
      */
-    static float Pawn(float x, float y, float z)
+    static FLOAT Pawn(FLOAT x, FLOAT y, FLOAT z)
     {
-        const float x_sqr = (x - 1.5f) * (x - 1.5f);
-        const float y_sqr = (y - 1.5f) * (y - 1.5f);
-        const float z1_sqr = (z - 0.75f) * (z - 0.75f);
-        const float z2_sqr = (1.f - z) * (1.f - z);
-        const float z3_sqr = (1.25f - z) * (1.25f - z);
+        const FLOAT x_sqr = (x - 1.5f) * (x - 1.5f);
+        const FLOAT y_sqr = (y - 1.5f) * (y - 1.5f);
+        const FLOAT z1_sqr = (z - 0.75f) * (z - 0.75f);
+        const FLOAT z2_sqr = (1.f - z) * (1.f - z);
+        const FLOAT z3_sqr = (1.25f - z) * (1.25f - z);
 
         return dis(con(con(0.25f - x_sqr - y_sqr, -20.f * (x_sqr + y_sqr) + 1.f + 10.f * z1_sqr), z * (1.f - z)),
                    dis(0.125f - x_sqr - y_sqr - 20.f * z2_sqr, 0.05f - x_sqr - y_sqr - z3_sqr));
@@ -48,19 +48,19 @@ public:
      * @param z    The z-coordinate.
      * @return a value that > 0 inside the object, = 0 on the border and < 0 outside.
      */
-    static float Bishop(float x, float y, float z)
+    static FLOAT Bishop(FLOAT x, FLOAT y, FLOAT z)
     {
-        const float x_sqr = (x - 1.5f) * (x - 1.5f);
-        const float y_sqr = (y - 1.5f) * (y - 1.5f);
-        const float z1_sqr = (z - 0.85f) * (z - 0.85f);
-        const float z2_sqr = (1.25f - z) * (1.25f - z);
-        const float z3_sqr = (1.4f - z) * (1.4f - z);
+        const FLOAT x_sqr = (x - 1.5f) * (x - 1.5f);
+        const FLOAT y_sqr = (y - 1.5f) * (y - 1.5f);
+        const FLOAT z1_sqr = (z - 0.85f) * (z - 0.85f);
+        const FLOAT z2_sqr = (1.25f - z) * (1.25f - z);
+        const FLOAT z3_sqr = (1.4f - z) * (1.4f - z);
 
         return dis(con(con(0.25f - x_sqr - y_sqr, -20.f * (x_sqr + y_sqr) + 1.f + 10.f * z1_sqr), z * (1.25f - z)),
                    dis(0.2f - x_sqr - y_sqr - 20.f * z2_sqr, 0.2f - 5.f * x_sqr - 4.f * y_sqr - z3_sqr));
     }
 };
 
-} // namespace SPHAlgorithms
+} // namespace SPHSDK
 
 #endif // SHAPES_H_19D5A367806A431C96F39D5F50B94D31

--- a/algorithms/test/src/AreaTestSuite.cpp
+++ b/algorithms/test/src/AreaTestSuite.cpp
@@ -8,7 +8,7 @@
 
 #include <gtest/gtest.h>
 
-namespace SPHAlgorithms::TestEnvironment {
+namespace SPHSDK::TestEnvironment {
 
 void AreaTestSuite::testDefaultCtor()
 {
@@ -24,14 +24,14 @@ void AreaTestSuite::testAreaFunction()
 void AreaTestSuite::testIsInsideArea()
 {
   Area a;
-  Point2D p;
+  Point2F p;
 
   ASSERT_FALSE(a.isInsideArea(p));
 }
 
-} // SPHAlgorithms::TestEnvironment
+} // SPHSDK::TestEnvironment
 
-using namespace SPHAlgorithms::TestEnvironment;
+using namespace SPHSDK::TestEnvironment;
 
 TEST(AreaTestSuite, testDefaultCtor)
 {

--- a/algorithms/test/src/AreaTestSuite.h
+++ b/algorithms/test/src/AreaTestSuite.h
@@ -2,7 +2,7 @@
 #ifndef AREA_TEST_SUITE_H_96192C2023784EE0B4976A48A1A87794
 #define AREA_TEST_SUITE_H_96192C2023784EE0B4976A48A1A87794
 
-namespace SPHAlgorithms::TestEnvironment
+namespace SPHSDK::TestEnvironment
 {
 
 class AreaTestSuite {
@@ -14,7 +14,7 @@ public:
   static void testIsInsideArea();
 };
 
-} // SPHAlgorithms::TestEnvironment
+} // namespace SPHSDK::TestEnvironment
 
 
 #endif // AREA_TEST_SUITE_H_96192C2023784EE0B4976A48A1A87794

--- a/algorithms/test/src/MarchingCubesTestSuite.cpp
+++ b/algorithms/test/src/MarchingCubesTestSuite.cpp
@@ -16,7 +16,7 @@
 
 
 // Generates Obj file in Wavefront format with mesh
-static void generateObjFile(const std::vector<SPHAlgorithms::Point3F>& vertices, const std::string& fileName)
+static void generateObjFile(const std::vector<SPHSDK::Point3F>& vertices, const std::string& fileName)
 {
     std::ofstream file(fileName);
     if (!file)
@@ -40,14 +40,14 @@ static void generateObjFile(const std::vector<SPHAlgorithms::Point3F>& vertices,
     file.close();
 }
 
-namespace SPHAlgorithms
+namespace SPHSDK
 {
 namespace TestEnvironment
 {
 
 void MarchingCubesTestSuite::generatePawnMesh()
 {
-    const Point3FVector mesh = SPHAlgorithms::MarchingCubes::generateMesh(Shapes::Pawn);
+    const Point3FVector mesh = MarchingCubes::generateMesh(Shapes::Pawn);
 
     ASSERT_EQ(37128u, mesh.size());
 
@@ -56,7 +56,7 @@ void MarchingCubesTestSuite::generatePawnMesh()
 
 void MarchingCubesTestSuite::generateBishopMesh()
 {
-    const Point3FVector mesh = SPHAlgorithms::MarchingCubes::generateMesh(Shapes::Bishop);
+    const Point3FVector mesh = MarchingCubes::generateMesh(Shapes::Bishop);
 
     ASSERT_EQ(45552u, mesh.size());
 
@@ -64,9 +64,9 @@ void MarchingCubesTestSuite::generateBishopMesh()
 }
 
 } // namespace TestEnvironment
-} // namespace SPHAlgorithms
+} // namespace SPHSDK
 
-using namespace SPHAlgorithms::TestEnvironment;
+using namespace SPHSDK::TestEnvironment;
 
 TEST(MarchingCubesTestSuite, generatePawnMesh)
 {

--- a/algorithms/test/src/MarchingCubesTestSuite.h
+++ b/algorithms/test/src/MarchingCubesTestSuite.h
@@ -8,7 +8,7 @@
 #ifndef MARCHING_CUBES_TEST_SUITE_H_96192C2023784EE0B4976A48A1A8779R
 #define MARCHING_CUBES_TEST_SUITE_H_96192C2023784EE0B4976A48A1A8779R
 
-namespace SPHAlgorithms
+namespace SPHSDK
 {
 
 namespace TestEnvironment
@@ -23,6 +23,6 @@ public:
 };
 
 } // namespace TestEnvironment
-} // namespace SPHAlgorithms
+} // namespace SPHSDK
 
 #endif // MARCHING_CUBES_TEST_SUITE_H_96192C2023784EE0B4976A48A1A8779R

--- a/algorithms/test/src/NeighboursSearchTestSuite.cpp
+++ b/algorithms/test/src/NeighboursSearchTestSuite.cpp
@@ -285,11 +285,11 @@ void NeighboursSearchTestSuite::searchInCornerOfBoxesCorners()
 
 void NeighboursSearchTestSuite::searchInOneBox3D()
 {
-    TestPoints3D points = { Point3D(0.5, 0.5, 0.5),
-                            Point3D(0.6, 0.6, 0.6),
-                            Point3D(0.7, 0.7, 0.7) };
+    TestPoints3D points = { Point3F(0.5, 0.5, 0.5),
+                            Point3F(0.6, 0.6, 0.6),
+                            Point3F(0.7, 0.7, 0.7) };
 
-    testSearch3D(Cuboid(Point3D(0., 0., 0.), 1.0, 1.0, 1.0),  // areaRect
+    testSearch3D(Cuboid(Point3F(0., 0., 0.), 1.0, 1.0, 1.0),  // areaRect
                  0.5,                                         // radius
                  0.001,                                       // accuracy
                  points,                                      // points
@@ -313,14 +313,14 @@ void NeighboursSearchTestSuite::searchInOneBox3D()
 
 void NeighboursSearchTestSuite::searchInDifferentBoxesCenterBack3D()
 {
-    TestPoints3D points = { Point3D(0.75, 0.25, 0.75),   // 10
-                            Point3D(0.45, 0.25, 0.75),   // 9
-                            Point3D(0.75, 0.25, 0.45),   // 1
-                            Point3D(1.05, 0.25, 0.75),   // 11
-                            Point3D(0.75, 0.25, 1.05),   // 19
-                            Point3D(0.75, 0.75, 0.75) }; // 13
+    TestPoints3D points = { Point3F(0.75, 0.25, 0.75),   // 10
+                            Point3F(0.45, 0.25, 0.75),   // 9
+                            Point3F(0.75, 0.25, 0.45),   // 1
+                            Point3F(1.05, 0.25, 0.75),   // 11
+                            Point3F(0.75, 0.25, 1.05),   // 19
+                            Point3F(0.75, 0.75, 0.75) }; // 13
 
-    testSearch3D(Cuboid(Point3D(0., 0., 0.), 1.5, 1.5, 1.5),  // areaRect
+    testSearch3D(Cuboid(Point3F(0., 0., 0.), 1.5, 1.5, 1.5),  // areaRect
                  0.5,                                         // radius
                  0.001,                                       // accuracy
                  points,                                      // points
@@ -367,16 +367,16 @@ void NeighboursSearchTestSuite::searchInDifferentBoxesCenterBack3D()
 
 void NeighboursSearchTestSuite::searchInDifferentBoxesCenterMiddle3D()
 {
-    TestPoints3D points = { Point3D(0.15, 0.35, 0.15),   // 33
-                            Point3D(0.2, 0.35, 0.15),    // 34
-                            Point3D(0.09, 0.35, 0.15),   // 32
-                            Point3D(0.15, 0.35, 0.2),    // 53
-                            Point3D(0.15, 0.35, 0.09),   // 13
-                            Point3D(0.2, 0.29, 0.2),     // 50
-                            Point3D(0.09, 0.29, 0.09),   // 8
-                            Point3D(0.09, 0.41, 0.2),    // 56
-                            Point3D(0.2, 0.41, 0.09) };  // 18
-    testSearch3D(Cuboid(Point3D(0., 0., 0.), 0.4, 0.5, 0.3001),  // areaRect
+    TestPoints3D points = { Point3F(0.15, 0.35, 0.15),   // 33
+                            Point3F(0.2, 0.35, 0.15),    // 34
+                            Point3F(0.09, 0.35, 0.15),   // 32
+                            Point3F(0.15, 0.35, 0.2),    // 53
+                            Point3F(0.15, 0.35, 0.09),   // 13
+                            Point3F(0.2, 0.29, 0.2),     // 50
+                            Point3F(0.09, 0.29, 0.09),   // 8
+                            Point3F(0.09, 0.41, 0.2),    // 56
+                            Point3F(0.2, 0.41, 0.09) };  // 18
+    testSearch3D(Cuboid(Point3F(0., 0., 0.), 0.4, 0.5, 0.3001),  // areaRect
                  0.1,                                         // radius
                  0.001,                                       // accuracy
                  points,                                      // points

--- a/algorithms/test/src/NeighboursSearchTestSuite.cpp
+++ b/algorithms/test/src/NeighboursSearchTestSuite.cpp
@@ -16,14 +16,14 @@
 
 #include <gtest/gtest.h>
 
-namespace SPHAlgorithms
+namespace SPHSDK
 {
 namespace TestEnvironment
 {
 
 void NeighboursSearchTestSuite::testSearch(const Rect&                 areaRect,
-                                           double                      radius,
-                                           double                      accuracy,
+                                           FLOAT                      radius,
+                                           FLOAT                      accuracy,
                                            TestPoints&                 points,
                                            const SizetVector&          expectedBoxSizes,
                                            const VectorOfSizetVectors& expectedNeighbours)
@@ -50,8 +50,8 @@ void NeighboursSearchTestSuite::testSearch(const Rect&                 areaRect,
 }
 
 void NeighboursSearchTestSuite::testInsert(const Rect&                 areaRect,
-                                           double                      radius,
-                                           double                      accuracy,
+                                           FLOAT                      radius,
+                                           FLOAT                      accuracy,
                                            TestPoints&                 points,
                                            const SizetVector&          expectedBoxSizes,
                                            const VectorOfSizetVectors& expectedPointsInBoxes)
@@ -84,8 +84,8 @@ void NeighboursSearchTestSuite::testInsert(const Rect&                 areaRect,
 //----------------------------------
 
 void NeighboursSearchTestSuite::testSearch3D(const Cuboid&             cuboid,
-                                           double                      radius,
-                                           double                      accuracy,
+                                           FLOAT                      radius,
+                                           FLOAT                      accuracy,
                                            TestPoints3D&               points,
                                            const SizetVector&          expectedBoxSizes,
                                            const VectorOfSizetVectors& expectedBoxNeighbours,
@@ -115,8 +115,8 @@ void NeighboursSearchTestSuite::testSearch3D(const Cuboid&             cuboid,
 }
 
 void NeighboursSearchTestSuite::testInsert3D(const Cuboid&               cuboid,
-                                             double                      radius,
-                                             double                      accuracy,
+                                             FLOAT                      radius,
+                                             FLOAT                      accuracy,
                                              TestPoints3D&               points,
                                              const SizetVector&          expectedBoxSizes,
                                              const VectorOfSizetVectors& expectedPointsInBoxes)
@@ -146,9 +146,9 @@ void NeighboursSearchTestSuite::testInsert3D(const Cuboid&               cuboid,
 
 void NeighboursSearchTestSuite::searchInOneBox()
 {
-    TestPoints points = {Point2D(0.5, 0.5), Point2D(0.6, 0.6), Point2D(0.7, 0.7)};
+    TestPoints points = {Point2F(0.5, 0.5), Point2F(0.6, 0.6), Point2F(0.7, 0.7)};
 
-    testSearch(Rect(Point2D(0., 0.), Point2D(1.0, 1.0)), // areaRect
+    testSearch(Rect(Point2F(0., 0.), Point2F(1.0, 1.0)), // areaRect
                0.5,                                      // radius
                0.001,                                    // accuracy
                points,                                   // points
@@ -158,9 +158,9 @@ void NeighboursSearchTestSuite::searchInOneBox()
 
 void NeighboursSearchTestSuite::searchInDifferentBoxesRightBottom()
 {
-    TestPoints points = {Point2D(3.5, 0.5), Point2D(2.5, 0.5), Point2D(2.5, 1.5), Point2D(3.5, 1.5)};
+    TestPoints points = {Point2F(3.5, 0.5), Point2F(2.5, 0.5), Point2F(2.5, 1.5), Point2F(3.5, 1.5)};
 
-    testSearch(Rect(Point2D(0., 0.), Point2D(4.0, 4.0)),         // areaRect
+    testSearch(Rect(Point2F(0., 0.), Point2F(4.0, 4.0)),         // areaRect
                1.0,                                              // radius
                0.001,                                            // accuracy
                points,                                           // points
@@ -170,9 +170,9 @@ void NeighboursSearchTestSuite::searchInDifferentBoxesRightBottom()
 
 void NeighboursSearchTestSuite::searchInDifferentBoxesLeftBottom()
 {
-    TestPoints points = {Point2D(0.5, 0.5), Point2D(1.5, 0.5), Point2D(0.5, 1.5), Point2D(1.5, 1.5)};
+    TestPoints points = {Point2F(0.5, 0.5), Point2F(1.5, 0.5), Point2F(0.5, 1.5), Point2F(1.5, 1.5)};
 
-    testSearch(Rect(Point2D(0., 0.), Point2D(4.0, 4.0)),         // areaRect
+    testSearch(Rect(Point2F(0., 0.), Point2F(4.0, 4.0)),         // areaRect
                1.0,                                              // radius
                0.001,                                            // accuracy
                points,                                           // points
@@ -182,9 +182,9 @@ void NeighboursSearchTestSuite::searchInDifferentBoxesLeftBottom()
 
 void NeighboursSearchTestSuite::searchInDifferentBoxesRightTop()
 {
-    TestPoints points = {Point2D(3.5, 3.5), Point2D(2.5, 3.5), Point2D(2.5, 2.5), Point2D(3.5, 2.5)};
+    TestPoints points = {Point2F(3.5, 3.5), Point2F(2.5, 3.5), Point2F(2.5, 2.5), Point2F(3.5, 2.5)};
 
-    testSearch(Rect(Point2D(0., 0.), Point2D(4.0, 4.0)),         // areaRect
+    testSearch(Rect(Point2F(0., 0.), Point2F(4.0, 4.0)),         // areaRect
                1.0,                                              // radius
                0.001,                                            // accuracy
                points,                                           // points
@@ -194,9 +194,9 @@ void NeighboursSearchTestSuite::searchInDifferentBoxesRightTop()
 
 void NeighboursSearchTestSuite::searchInDifferentBoxesLeftTop()
 {
-    TestPoints points = {Point2D(0.5, 3.5), Point2D(1.5, 3.5), Point2D(0.5, 2.5), Point2D(1.5, 2.5)};
+    TestPoints points = {Point2F(0.5, 3.5), Point2F(1.5, 3.5), Point2F(0.5, 2.5), Point2F(1.5, 2.5)};
 
-    testSearch(Rect(Point2D(0., 0.), Point2D(4.0, 4.0)),         // areaRect
+    testSearch(Rect(Point2F(0., 0.), Point2F(4.0, 4.0)),         // areaRect
                1.0,                                              // radius
                0.001,                                            // accuracy
                points,                                           // points
@@ -206,10 +206,10 @@ void NeighboursSearchTestSuite::searchInDifferentBoxesLeftTop()
 
 void NeighboursSearchTestSuite::searchInDifferentBoxesRightSide()
 {
-    TestPoints points = {Point2D(3.5, 2.5), Point2D(3.5, 3.5), Point2D(2.5, 3.5),
-                         Point2D(2.5, 2.5), Point2D(2.5, 1.5), Point2D(3.5, 1.5)};
+    TestPoints points = {Point2F(3.5, 2.5), Point2F(3.5, 3.5), Point2F(2.5, 3.5),
+                         Point2F(2.5, 2.5), Point2F(2.5, 1.5), Point2F(3.5, 1.5)};
 
-    testSearch(Rect(Point2D(0., 0.), Point2D(4.0, 4.0)),                // areaRect
+    testSearch(Rect(Point2F(0., 0.), Point2F(4.0, 4.0)),                // areaRect
                1.0,                                                     // radius
                0.001,                                                   // accuracy
                points,                                                  // points
@@ -219,10 +219,10 @@ void NeighboursSearchTestSuite::searchInDifferentBoxesRightSide()
 
 void NeighboursSearchTestSuite::searchInDifferentBoxesLeftSide()
 {
-    TestPoints points = {Point2D(0.5, 2.5), Point2D(0.5, 3.5), Point2D(1.5, 3.5),
-                         Point2D(1.5, 2.5), Point2D(1.5, 1.5), Point2D(0.5, 1.5)};
+    TestPoints points = {Point2F(0.5, 2.5), Point2F(0.5, 3.5), Point2F(1.5, 3.5),
+                         Point2F(1.5, 2.5), Point2F(1.5, 1.5), Point2F(0.5, 1.5)};
 
-    testSearch(Rect(Point2D(0., 0.), Point2D(4.0, 4.0)),                // areaRect
+    testSearch(Rect(Point2F(0., 0.), Point2F(4.0, 4.0)),                // areaRect
                1.0,                                                     // radius
                0.001,                                                   // accuracy
                points,                                                  // points
@@ -232,10 +232,10 @@ void NeighboursSearchTestSuite::searchInDifferentBoxesLeftSide()
 
 void NeighboursSearchTestSuite::searchInDifferentBoxesCenterBottom()
 {
-    TestPoints points = {Point2D(1.5, 0.5), Point2D(0.5, 0.5), Point2D(0.5, 1.5),
-                         Point2D(1.5, 1.5), Point2D(2.5, 1.5), Point2D(2.5, 0.5)};
+    TestPoints points = {Point2F(1.5, 0.5), Point2F(0.5, 0.5), Point2F(0.5, 1.5),
+                         Point2F(1.5, 1.5), Point2F(2.5, 1.5), Point2F(2.5, 0.5)};
 
-    testSearch(Rect(Point2D(0., 0.), Point2D(4.0, 4.0)),                // areaRect
+    testSearch(Rect(Point2F(0., 0.), Point2F(4.0, 4.0)),                // areaRect
                1.0,                                                     // radius
                0.001,                                                   // accuracy
                points,                                                  // points
@@ -245,10 +245,10 @@ void NeighboursSearchTestSuite::searchInDifferentBoxesCenterBottom()
 
 void NeighboursSearchTestSuite::searchInDifferentBoxesCenterTop()
 {
-    TestPoints points = {Point2D(1.5, 3.5), Point2D(0.5, 3.5), Point2D(0.5, 2.5),
-                         Point2D(1.5, 2.5), Point2D(2.5, 2.5), Point2D(2.5, 3.5)};
+    TestPoints points = {Point2F(1.5, 3.5), Point2F(0.5, 3.5), Point2F(0.5, 2.5),
+                         Point2F(1.5, 2.5), Point2F(2.5, 2.5), Point2F(2.5, 3.5)};
 
-    testSearch(Rect(Point2D(0., 0.), Point2D(4.0, 4.0)),                // areaRect
+    testSearch(Rect(Point2F(0., 0.), Point2F(4.0, 4.0)),                // areaRect
                1.0,                                                     // radius
                0.001,                                                   // accuracy
                points,                                                  // points
@@ -258,9 +258,9 @@ void NeighboursSearchTestSuite::searchInDifferentBoxesCenterTop()
 
 void NeighboursSearchTestSuite::searchInCornerOfBoxesCenter()
 {
-    TestPoints points = {Point2D(1.0, 1.0), Point2D(1.0, 2.0), Point2D(1.0, 0.0), Point2D(0.0, 1.0), Point2D(2.0, 1.0)};
+    TestPoints points = {Point2F(1.0, 1.0), Point2F(1.0, 2.0), Point2F(1.0, 0.0), Point2F(0.0, 1.0), Point2F(2.0, 1.0)};
 
-    testSearch(Rect(Point2D(0., 0.), Point2D(2.0, 2.0)), // areaRect
+    testSearch(Rect(Point2F(0., 0.), Point2F(2.0, 2.0)), // areaRect
                1.0,                                      // radius
                0.001,                                    // accuracy
                points,                                   // points
@@ -270,10 +270,10 @@ void NeighboursSearchTestSuite::searchInCornerOfBoxesCenter()
 
 void NeighboursSearchTestSuite::searchInCornerOfBoxesCorners()
 {
-    TestPoints points = {Point2D(0., 0.), Point2D(0., 1.), Point2D(0., 2.), Point2D(1., 2.),
-                         Point2D(2., 2.), Point2D(2., 1.), Point2D(2., 0.), Point2D(1., 0.)};
+    TestPoints points = {Point2F(0., 0.), Point2F(0., 1.), Point2F(0., 2.), Point2F(1., 2.),
+                         Point2F(2., 2.), Point2F(2., 1.), Point2F(2., 0.), Point2F(1., 0.)};
 
-    testSearch(Rect(Point2D(0., 0.), Point2D(2.0, 2.0)),                          // areaRect
+    testSearch(Rect(Point2F(0., 0.), Point2F(2.0, 2.0)),                          // areaRect
                1.0,                                                               // radius
                0.001,                                                             // accuracy
                points,                                                            // points
@@ -461,10 +461,10 @@ void NeighboursSearchTestSuite::searchInDifferentBoxesCenterMiddle3D()
 
 void NeighboursSearchTestSuite::insertPointsIntoBoxesCornerPoints()
 {
-    TestPoints points = {Point2D(0.0, 0.0), Point2D(2.0, 0.0), Point2D(4.0, 0.0), Point2D(0.0, 2.0), Point2D(0.0, 4.0),
-                         Point2D(2.0, 2.0), Point2D(2.0, 4.0), Point2D(4.0, 2.0), Point2D(4.0, 4.0)};
+    TestPoints points = {Point2F(0.0, 0.0), Point2F(2.0, 0.0), Point2F(4.0, 0.0), Point2F(0.0, 2.0), Point2F(0.0, 4.0),
+                         Point2F(2.0, 2.0), Point2F(2.0, 4.0), Point2F(4.0, 2.0), Point2F(4.0, 4.0)};
 
-    testInsert(Rect(Point2D(0., 0.), Point2D(4.0, 4.0)), // areaRect
+    testInsert(Rect(Point2F(0., 0.), Point2F(4.0, 4.0)), // areaRect
                2.0,                                      // radius
                0.001,                                    // accuracy
                points,                                   // points
@@ -474,10 +474,10 @@ void NeighboursSearchTestSuite::insertPointsIntoBoxesCornerPoints()
 
 void NeighboursSearchTestSuite::insertPointsIntoBoxesBorderPoints()
 {
-    TestPoints points = {Point2D(0.0, 1.0), Point2D(0.0, 3.0), Point2D(1.0, 4.0), Point2D(3.0, 4.0),
-                         Point2D(4.0, 3.0), Point2D(4.0, 1.0), Point2D(3.0, 0.0), Point2D(1.0, 0.0)};
+    TestPoints points = {Point2F(0.0, 1.0), Point2F(0.0, 3.0), Point2F(1.0, 4.0), Point2F(3.0, 4.0),
+                         Point2F(4.0, 3.0), Point2F(4.0, 1.0), Point2F(3.0, 0.0), Point2F(1.0, 0.0)};
 
-    testInsert(Rect(Point2D(0., 0.), Point2D(4.0, 4.0)), // areaRect
+    testInsert(Rect(Point2F(0., 0.), Point2F(4.0, 4.0)), // areaRect
                2.0,                                      // radius
                0.001,                                    // accuracy
                points,                                   // points
@@ -487,14 +487,14 @@ void NeighboursSearchTestSuite::insertPointsIntoBoxesBorderPoints()
 
 void NeighboursSearchTestSuite::insertPointsIntoBoxesInnerPoints()
 {
-    TestPoints points = {Point2D(0.5, 0.5), Point2D(1.0, 1.0), Point2D(1.5, 1.5), Point2D(2.5, 0.5), Point2D(3.0, 1.0),
-                         Point2D(3.5, 1.5), Point2D(4.5, 0.5), Point2D(5.0, 1.0), Point2D(5.5, 1.5), Point2D(0.5, 2.5),
-                         Point2D(1.0, 3.0), Point2D(1.5, 3.5), Point2D(2.5, 2.5), Point2D(3.0, 3.0), Point2D(3.5, 3.5),
-                         Point2D(4.5, 2.5), Point2D(5.0, 3.0), Point2D(5.5, 3.5), Point2D(0.5, 4.5), Point2D(1.0, 5.0),
-                         Point2D(1.5, 5.5), Point2D(2.5, 4.5), Point2D(3.0, 5.0), Point2D(3.5, 5.5), Point2D(4.5, 4.5),
-                         Point2D(5.0, 5.0), Point2D(5.5, 5.5)};
+    TestPoints points = {Point2F(0.5, 0.5), Point2F(1.0, 1.0), Point2F(1.5, 1.5), Point2F(2.5, 0.5), Point2F(3.0, 1.0),
+                         Point2F(3.5, 1.5), Point2F(4.5, 0.5), Point2F(5.0, 1.0), Point2F(5.5, 1.5), Point2F(0.5, 2.5),
+                         Point2F(1.0, 3.0), Point2F(1.5, 3.5), Point2F(2.5, 2.5), Point2F(3.0, 3.0), Point2F(3.5, 3.5),
+                         Point2F(4.5, 2.5), Point2F(5.0, 3.0), Point2F(5.5, 3.5), Point2F(0.5, 4.5), Point2F(1.0, 5.0),
+                         Point2F(1.5, 5.5), Point2F(2.5, 4.5), Point2F(3.0, 5.0), Point2F(3.5, 5.5), Point2F(4.5, 4.5),
+                         Point2F(5.0, 5.0), Point2F(5.5, 5.5)};
 
-    testInsert(Rect(Point2D(0., 0.), Point2D(6.0, 6.0)), // areaRect
+    testInsert(Rect(Point2F(0., 0.), Point2F(6.0, 6.0)), // areaRect
                2.0,                                      // radius
                0.001,                                    // accuracy
                points,                                   // points
@@ -512,15 +512,15 @@ void NeighboursSearchTestSuite::insertPointsIntoBoxesInnerPoints()
 
 void NeighboursSearchTestSuite::insertPointsIntoBoxesCenterBoxFrame()
 {
-    TestPoints points = {Point2D(2.0, 2.0), Point2D(2.5, 2.5),       Point2D(3.0, 3.0),      Point2D(3.5, 3.5),
-                         Point2D(4.0, 4.0), Point2D(2.0001, 2.0001), Point2D(2.0, 4.0),      Point2D(2.5, 3.5),
-                         Point2D(3.5, 2.5), Point2D(4.0, 2.0),       Point2D(2.5, 3.0),      Point2D(3.5, 3.0),
-                         Point2D(3.0, 3.5), Point2D(3.0, 2.5),       Point2D(2.5, 2.0),      Point2D(3.0, 2.0),
-                         Point2D(3.5, 2.0), Point2D(2.5, 4.0),       Point2D(3.0, 4.0),      Point2D(3.5, 4.0),
-                         Point2D(2.0, 2.5), Point2D(2.0, 3.0),       Point2D(2.0, 3.5),      Point2D(4.0, 2.5),
-                         Point2D(4.0, 3.0), Point2D(4.0, 3.5),       Point2D(3.9999, 3.9999)};
+    TestPoints points = {Point2F(2.0, 2.0), Point2F(2.5, 2.5),       Point2F(3.0, 3.0),      Point2F(3.5, 3.5),
+                         Point2F(4.0, 4.0), Point2F(2.0001, 2.0001), Point2F(2.0, 4.0),      Point2F(2.5, 3.5),
+                         Point2F(3.5, 2.5), Point2F(4.0, 2.0),       Point2F(2.5, 3.0),      Point2F(3.5, 3.0),
+                         Point2F(3.0, 3.5), Point2F(3.0, 2.5),       Point2F(2.5, 2.0),      Point2F(3.0, 2.0),
+                         Point2F(3.5, 2.0), Point2F(2.5, 4.0),       Point2F(3.0, 4.0),      Point2F(3.5, 4.0),
+                         Point2F(2.0, 2.5), Point2F(2.0, 3.0),       Point2F(2.0, 3.5),      Point2F(4.0, 2.5),
+                         Point2F(4.0, 3.0), Point2F(4.0, 3.5),       Point2F(3.9999, 3.9999)};
 
-    testInsert(Rect(Point2D(0., 0.), Point2D(6.0, 6.0)), // areaRect
+    testInsert(Rect(Point2F(0., 0.), Point2F(6.0, 6.0)), // areaRect
                2.0,                                      // radius
                0.001,                                    // accuracy
                points,                                   // points
@@ -538,16 +538,16 @@ void NeighboursSearchTestSuite::insertPointsIntoBoxesCenterBoxFrame()
 
 void NeighboursSearchTestSuite::insertPointsIntoBoxesInnerFrame()
 {
-    TestPoints points = {Point2D(0.5, 2.0), Point2D(1.0, 2.0), Point2D(1.5, 2.0), Point2D(2.5, 2.0), Point2D(3.0, 2.0),
-                         Point2D(3.5, 2.0), Point2D(4.5, 2.0), Point2D(5.0, 2.0), Point2D(5.5, 2.0), Point2D(0.5, 4.0),
-                         Point2D(1.0, 4.0), Point2D(1.5, 4.0), Point2D(2.5, 4.0), Point2D(3.0, 4.0), Point2D(3.5, 4.0),
-                         Point2D(4.5, 4.0), Point2D(5.0, 4.0), Point2D(5.5, 4.0), Point2D(2.0, 0.5), Point2D(2.0, 1.0),
-                         Point2D(2.0, 1.5), Point2D(2.0, 2.5), Point2D(2.0, 3.0), Point2D(2.0, 3.5), Point2D(2.0, 4.5),
-                         Point2D(2.0, 5.0), Point2D(2.0, 5.5), Point2D(4.0, 0.5), Point2D(4.0, 1.0), Point2D(4.0, 1.5),
-                         Point2D(4.0, 2.5), Point2D(4.0, 3.0), Point2D(4.0, 3.5), Point2D(4.0, 4.5), Point2D(4.0, 5.0),
-                         Point2D(4.0, 5.5)};
+    TestPoints points = {Point2F(0.5, 2.0), Point2F(1.0, 2.0), Point2F(1.5, 2.0), Point2F(2.5, 2.0), Point2F(3.0, 2.0),
+                         Point2F(3.5, 2.0), Point2F(4.5, 2.0), Point2F(5.0, 2.0), Point2F(5.5, 2.0), Point2F(0.5, 4.0),
+                         Point2F(1.0, 4.0), Point2F(1.5, 4.0), Point2F(2.5, 4.0), Point2F(3.0, 4.0), Point2F(3.5, 4.0),
+                         Point2F(4.5, 4.0), Point2F(5.0, 4.0), Point2F(5.5, 4.0), Point2F(2.0, 0.5), Point2F(2.0, 1.0),
+                         Point2F(2.0, 1.5), Point2F(2.0, 2.5), Point2F(2.0, 3.0), Point2F(2.0, 3.5), Point2F(2.0, 4.5),
+                         Point2F(2.0, 5.0), Point2F(2.0, 5.5), Point2F(4.0, 0.5), Point2F(4.0, 1.0), Point2F(4.0, 1.5),
+                         Point2F(4.0, 2.5), Point2F(4.0, 3.0), Point2F(4.0, 3.5), Point2F(4.0, 4.5), Point2F(4.0, 5.0),
+                         Point2F(4.0, 5.5)};
 
-    testInsert(Rect(Point2D(0., 0.), Point2D(6.0, 6.0)), // areaRect
+    testInsert(Rect(Point2F(0., 0.), Point2F(6.0, 6.0)), // areaRect
                2.0,                                      // radius
                0.001,                                    // accuracy
                points,                                   // points
@@ -565,14 +565,14 @@ void NeighboursSearchTestSuite::insertPointsIntoBoxesInnerFrame()
 
 void NeighboursSearchTestSuite::insertPointsIntoBoxesTopRightBox()
 {
-    TestPoints points = {Point2D(4.0, 4.0), Point2D(4.5, 4.0), Point2D(5.0, 4.0), Point2D(5.5, 4.0), Point2D(6.0, 4.0),
-                         Point2D(4.0, 4.5), Point2D(4.5, 4.5), Point2D(5.0, 4.5), Point2D(5.5, 4.5), Point2D(6.0, 4.5),
-                         Point2D(4.0, 5.0), Point2D(4.5, 5.0), Point2D(5.0, 5.0), Point2D(5.5, 5.0), Point2D(6.0, 5.0),
-                         Point2D(4.0, 5.5), Point2D(4.5, 5.5), Point2D(5.0, 5.5), Point2D(5.5, 5.5), Point2D(6.0, 5.5),
-                         Point2D(4.0, 6.0), Point2D(4.5, 6.0), Point2D(5.0, 6.0), Point2D(5.5, 6.0), Point2D(6.0, 6.0)};
+    TestPoints points = {Point2F(4.0, 4.0), Point2F(4.5, 4.0), Point2F(5.0, 4.0), Point2F(5.5, 4.0), Point2F(6.0, 4.0),
+                         Point2F(4.0, 4.5), Point2F(4.5, 4.5), Point2F(5.0, 4.5), Point2F(5.5, 4.5), Point2F(6.0, 4.5),
+                         Point2F(4.0, 5.0), Point2F(4.5, 5.0), Point2F(5.0, 5.0), Point2F(5.5, 5.0), Point2F(6.0, 5.0),
+                         Point2F(4.0, 5.5), Point2F(4.5, 5.5), Point2F(5.0, 5.5), Point2F(5.5, 5.5), Point2F(6.0, 5.5),
+                         Point2F(4.0, 6.0), Point2F(4.5, 6.0), Point2F(5.0, 6.0), Point2F(5.5, 6.0), Point2F(6.0, 6.0)};
 
     testInsert(
-        Rect(Point2D(0., 0.), Point2D(6.0, 6.0)), // areaRect
+        Rect(Point2F(0., 0.), Point2F(6.0, 6.0)), // areaRect
         2.0,                                      // radius
         0.001,                                    // accuracy
         points,                                   // points
@@ -583,13 +583,13 @@ void NeighboursSearchTestSuite::insertPointsIntoBoxesTopRightBox()
 
 void NeighboursSearchTestSuite::insertPointsIntoBoxesTopLeftBox()
 {
-    TestPoints points = {Point2D(0.0, 4.0), Point2D(0.5, 4.0), Point2D(1.0, 4.0), Point2D(1.5, 4.0), Point2D(2.0, 4.0),
-                         Point2D(0.0, 4.5), Point2D(0.5, 4.5), Point2D(1.0, 4.5), Point2D(1.5, 4.5), Point2D(2.0, 4.5),
-                         Point2D(0.0, 5.0), Point2D(0.5, 5.0), Point2D(1.0, 5.0), Point2D(1.5, 5.0), Point2D(2.0, 5.0),
-                         Point2D(0.0, 5.5), Point2D(0.5, 5.5), Point2D(1.0, 5.5), Point2D(1.5, 5.5), Point2D(2.0, 5.5),
-                         Point2D(0.0, 6.0), Point2D(0.5, 6.0), Point2D(1.0, 6.0), Point2D(1.5, 6.0), Point2D(2.0, 6.0)};
+    TestPoints points = {Point2F(0.0, 4.0), Point2F(0.5, 4.0), Point2F(1.0, 4.0), Point2F(1.5, 4.0), Point2F(2.0, 4.0),
+                         Point2F(0.0, 4.5), Point2F(0.5, 4.5), Point2F(1.0, 4.5), Point2F(1.5, 4.5), Point2F(2.0, 4.5),
+                         Point2F(0.0, 5.0), Point2F(0.5, 5.0), Point2F(1.0, 5.0), Point2F(1.5, 5.0), Point2F(2.0, 5.0),
+                         Point2F(0.0, 5.5), Point2F(0.5, 5.5), Point2F(1.0, 5.5), Point2F(1.5, 5.5), Point2F(2.0, 5.5),
+                         Point2F(0.0, 6.0), Point2F(0.5, 6.0), Point2F(1.0, 6.0), Point2F(1.5, 6.0), Point2F(2.0, 6.0)};
 
-    testInsert(Rect(Point2D(0., 0.), Point2D(6.0, 6.0)), // areaRect
+    testInsert(Rect(Point2F(0., 0.), Point2F(6.0, 6.0)), // areaRect
                2.0,                                      // radius
                0.001,                                    // accuracy
                points,                                   // points
@@ -607,13 +607,13 @@ void NeighboursSearchTestSuite::insertPointsIntoBoxesTopLeftBox()
 
 void NeighboursSearchTestSuite::insertPointsIntoBoxesBottomLeftBox()
 {
-    TestPoints points = {Point2D(0.0, 0.0), Point2D(0.5, 0.0), Point2D(1.0, 0.0), Point2D(1.5, 0.0), Point2D(2.0, 0.0),
-                         Point2D(0.0, 0.5), Point2D(0.5, 0.5), Point2D(1.0, 0.5), Point2D(1.5, 0.5), Point2D(2.0, 0.5),
-                         Point2D(0.0, 1.0), Point2D(0.5, 1.0), Point2D(1.0, 1.0), Point2D(1.5, 1.0), Point2D(2.0, 1.0),
-                         Point2D(0.0, 1.5), Point2D(0.5, 1.5), Point2D(1.0, 1.5), Point2D(1.5, 1.5), Point2D(2.0, 1.5),
-                         Point2D(0.0, 2.0), Point2D(0.5, 2.0), Point2D(1.0, 2.0), Point2D(1.5, 2.0), Point2D(2.0, 2.0)};
+    TestPoints points = {Point2F(0.0, 0.0), Point2F(0.5, 0.0), Point2F(1.0, 0.0), Point2F(1.5, 0.0), Point2F(2.0, 0.0),
+                         Point2F(0.0, 0.5), Point2F(0.5, 0.5), Point2F(1.0, 0.5), Point2F(1.5, 0.5), Point2F(2.0, 0.5),
+                         Point2F(0.0, 1.0), Point2F(0.5, 1.0), Point2F(1.0, 1.0), Point2F(1.5, 1.0), Point2F(2.0, 1.0),
+                         Point2F(0.0, 1.5), Point2F(0.5, 1.5), Point2F(1.0, 1.5), Point2F(1.5, 1.5), Point2F(2.0, 1.5),
+                         Point2F(0.0, 2.0), Point2F(0.5, 2.0), Point2F(1.0, 2.0), Point2F(1.5, 2.0), Point2F(2.0, 2.0)};
 
-    testInsert(Rect(Point2D(0., 0.), Point2D(6.0, 6.0)), // areaRect
+    testInsert(Rect(Point2F(0., 0.), Point2F(6.0, 6.0)), // areaRect
                2.0,                                      // radius
                0.001,                                    // accuracy
                points,                                   // points
@@ -631,13 +631,13 @@ void NeighboursSearchTestSuite::insertPointsIntoBoxesBottomLeftBox()
 
 void NeighboursSearchTestSuite::insertPointsIntoBoxesBottomRightBox()
 {
-    TestPoints points = {Point2D(4.0, 0.0), Point2D(4.5, 0.0), Point2D(5.0, 0.0), Point2D(5.5, 0.0), Point2D(6.0, 0.0),
-                         Point2D(4.0, 0.5), Point2D(4.5, 0.5), Point2D(5.0, 0.5), Point2D(5.5, 0.5), Point2D(6.0, 0.5),
-                         Point2D(4.0, 1.0), Point2D(4.5, 1.0), Point2D(5.0, 1.0), Point2D(5.5, 1.0), Point2D(6.0, 1.0),
-                         Point2D(4.0, 1.5), Point2D(4.5, 1.5), Point2D(5.0, 1.5), Point2D(5.5, 1.5), Point2D(6.0, 1.5),
-                         Point2D(4.0, 2.0), Point2D(4.5, 2.0), Point2D(5.0, 2.0), Point2D(5.5, 2.0), Point2D(6.0, 2.0)};
+    TestPoints points = {Point2F(4.0, 0.0), Point2F(4.5, 0.0), Point2F(5.0, 0.0), Point2F(5.5, 0.0), Point2F(6.0, 0.0),
+                         Point2F(4.0, 0.5), Point2F(4.5, 0.5), Point2F(5.0, 0.5), Point2F(5.5, 0.5), Point2F(6.0, 0.5),
+                         Point2F(4.0, 1.0), Point2F(4.5, 1.0), Point2F(5.0, 1.0), Point2F(5.5, 1.0), Point2F(6.0, 1.0),
+                         Point2F(4.0, 1.5), Point2F(4.5, 1.5), Point2F(5.0, 1.5), Point2F(5.5, 1.5), Point2F(6.0, 1.5),
+                         Point2F(4.0, 2.0), Point2F(4.5, 2.0), Point2F(5.0, 2.0), Point2F(5.5, 2.0), Point2F(6.0, 2.0)};
 
-    testInsert(Rect(Point2D(0., 0.), Point2D(6.0, 6.0)), // areaRect
+    testInsert(Rect(Point2F(0., 0.), Point2F(6.0, 6.0)), // areaRect
                2.0,                                      // radius
                0.001,                                    // accuracy
                points,                                   // points
@@ -655,13 +655,13 @@ void NeighboursSearchTestSuite::insertPointsIntoBoxesBottomRightBox()
 
 void NeighboursSearchTestSuite::insertPointsIntoBoxesBottomCenterBox()
 {
-    TestPoints points = {Point2D(2.0, 0.0), Point2D(2.5, 0.0), Point2D(3.0, 0.0), Point2D(3.5, 0.0), Point2D(4.0, 0.0),
-                         Point2D(2.0, 0.5), Point2D(2.5, 0.5), Point2D(3.0, 0.5), Point2D(3.5, 0.5), Point2D(4.0, 0.5),
-                         Point2D(2.0, 1.0), Point2D(2.5, 1.0), Point2D(3.0, 1.0), Point2D(3.5, 1.0), Point2D(4.0, 1.0),
-                         Point2D(2.0, 1.5), Point2D(2.5, 1.5), Point2D(3.0, 1.5), Point2D(3.5, 1.5), Point2D(4.0, 1.5),
-                         Point2D(2.0, 2.0), Point2D(2.5, 2.0), Point2D(3.0, 2.0), Point2D(3.5, 2.0), Point2D(4.0, 2.0)};
+    TestPoints points = {Point2F(2.0, 0.0), Point2F(2.5, 0.0), Point2F(3.0, 0.0), Point2F(3.5, 0.0), Point2F(4.0, 0.0),
+                         Point2F(2.0, 0.5), Point2F(2.5, 0.5), Point2F(3.0, 0.5), Point2F(3.5, 0.5), Point2F(4.0, 0.5),
+                         Point2F(2.0, 1.0), Point2F(2.5, 1.0), Point2F(3.0, 1.0), Point2F(3.5, 1.0), Point2F(4.0, 1.0),
+                         Point2F(2.0, 1.5), Point2F(2.5, 1.5), Point2F(3.0, 1.5), Point2F(3.5, 1.5), Point2F(4.0, 1.5),
+                         Point2F(2.0, 2.0), Point2F(2.5, 2.0), Point2F(3.0, 2.0), Point2F(3.5, 2.0), Point2F(4.0, 2.0)};
 
-    testInsert(Rect(Point2D(0., 0.), Point2D(6.0, 6.0)), // areaRect
+    testInsert(Rect(Point2F(0., 0.), Point2F(6.0, 6.0)), // areaRect
                2.0,                                      // radius
                0.001,                                    // accuracy
                points,                                   // points
@@ -679,13 +679,13 @@ void NeighboursSearchTestSuite::insertPointsIntoBoxesBottomCenterBox()
 
 void NeighboursSearchTestSuite::insertPointsIntoBoxesLeftCenterBox()
 {
-    TestPoints points = {Point2D(0.0, 2.0), Point2D(0.5, 2.0), Point2D(1.0, 2.0), Point2D(1.5, 2.0), Point2D(2.0, 2.0),
-                         Point2D(0.0, 2.5), Point2D(0.5, 2.5), Point2D(1.0, 2.5), Point2D(1.5, 2.5), Point2D(2.0, 2.5),
-                         Point2D(0.0, 3.0), Point2D(0.5, 3.0), Point2D(1.0, 3.0), Point2D(1.5, 3.0), Point2D(2.0, 3.0),
-                         Point2D(0.0, 3.5), Point2D(0.5, 3.5), Point2D(1.0, 3.5), Point2D(1.5, 3.5), Point2D(2.0, 3.5),
-                         Point2D(0.0, 4.0), Point2D(0.5, 4.0), Point2D(1.0, 4.0), Point2D(1.5, 4.0), Point2D(2.0, 4.0)};
+    TestPoints points = {Point2F(0.0, 2.0), Point2F(0.5, 2.0), Point2F(1.0, 2.0), Point2F(1.5, 2.0), Point2F(2.0, 2.0),
+                         Point2F(0.0, 2.5), Point2F(0.5, 2.5), Point2F(1.0, 2.5), Point2F(1.5, 2.5), Point2F(2.0, 2.5),
+                         Point2F(0.0, 3.0), Point2F(0.5, 3.0), Point2F(1.0, 3.0), Point2F(1.5, 3.0), Point2F(2.0, 3.0),
+                         Point2F(0.0, 3.5), Point2F(0.5, 3.5), Point2F(1.0, 3.5), Point2F(1.5, 3.5), Point2F(2.0, 3.5),
+                         Point2F(0.0, 4.0), Point2F(0.5, 4.0), Point2F(1.0, 4.0), Point2F(1.5, 4.0), Point2F(2.0, 4.0)};
 
-    testInsert(Rect(Point2D(0., 0.), Point2D(6.0, 6.0)), // areaRect
+    testInsert(Rect(Point2F(0., 0.), Point2F(6.0, 6.0)), // areaRect
                2.0,                                      // radius
                0.001,                                    // accuracy
                points,                                   // points
@@ -703,13 +703,13 @@ void NeighboursSearchTestSuite::insertPointsIntoBoxesLeftCenterBox()
 
 void NeighboursSearchTestSuite::insertPointsIntoBoxesTopCenterBox()
 {
-    TestPoints points = {Point2D(2.0, 4.0), Point2D(2.5, 4.0), Point2D(3.0, 4.0), Point2D(3.5, 4.0), Point2D(4.0, 4.0),
-                         Point2D(2.0, 4.5), Point2D(2.5, 4.5), Point2D(3.0, 4.5), Point2D(3.5, 4.5), Point2D(4.0, 4.5),
-                         Point2D(2.0, 5.0), Point2D(2.5, 5.0), Point2D(3.0, 5.0), Point2D(3.5, 5.0), Point2D(4.0, 5.0),
-                         Point2D(2.0, 5.5), Point2D(2.5, 5.5), Point2D(3.0, 5.5), Point2D(3.5, 5.5), Point2D(4.0, 5.5),
-                         Point2D(2.0, 6.0), Point2D(2.5, 6.0), Point2D(3.0, 6.0), Point2D(3.5, 6.0), Point2D(4.0, 6.0)};
+    TestPoints points = {Point2F(2.0, 4.0), Point2F(2.5, 4.0), Point2F(3.0, 4.0), Point2F(3.5, 4.0), Point2F(4.0, 4.0),
+                         Point2F(2.0, 4.5), Point2F(2.5, 4.5), Point2F(3.0, 4.5), Point2F(3.5, 4.5), Point2F(4.0, 4.5),
+                         Point2F(2.0, 5.0), Point2F(2.5, 5.0), Point2F(3.0, 5.0), Point2F(3.5, 5.0), Point2F(4.0, 5.0),
+                         Point2F(2.0, 5.5), Point2F(2.5, 5.5), Point2F(3.0, 5.5), Point2F(3.5, 5.5), Point2F(4.0, 5.5),
+                         Point2F(2.0, 6.0), Point2F(2.5, 6.0), Point2F(3.0, 6.0), Point2F(3.5, 6.0), Point2F(4.0, 6.0)};
 
-    testInsert(Rect(Point2D(0., 0.), Point2D(6.0, 6.0)), // areaRect
+    testInsert(Rect(Point2F(0., 0.), Point2F(6.0, 6.0)), // areaRect
                2.0,                                      // radius
                0.001,                                    // accuracy
                points,                                   // points
@@ -727,13 +727,13 @@ void NeighboursSearchTestSuite::insertPointsIntoBoxesTopCenterBox()
 
 void NeighboursSearchTestSuite::insertPointsIntoBoxesRightCenterBox()
 {
-    TestPoints points = {Point2D(4.0, 2.0), Point2D(4.5, 2.0), Point2D(5.0, 2.0), Point2D(5.5, 2.0), Point2D(6.0, 2.0),
-                         Point2D(4.0, 2.5), Point2D(4.5, 2.5), Point2D(5.0, 2.5), Point2D(5.5, 2.5), Point2D(6.0, 2.5),
-                         Point2D(4.0, 3.0), Point2D(4.5, 3.0), Point2D(5.0, 3.0), Point2D(5.5, 3.0), Point2D(6.0, 3.0),
-                         Point2D(4.0, 3.5), Point2D(4.5, 3.5), Point2D(5.0, 3.5), Point2D(5.5, 3.5), Point2D(6.0, 3.5),
-                         Point2D(4.0, 4.0), Point2D(4.5, 4.0), Point2D(5.0, 4.0), Point2D(5.5, 4.0), Point2D(6.0, 4.0)};
+    TestPoints points = {Point2F(4.0, 2.0), Point2F(4.5, 2.0), Point2F(5.0, 2.0), Point2F(5.5, 2.0), Point2F(6.0, 2.0),
+                         Point2F(4.0, 2.5), Point2F(4.5, 2.5), Point2F(5.0, 2.5), Point2F(5.5, 2.5), Point2F(6.0, 2.5),
+                         Point2F(4.0, 3.0), Point2F(4.5, 3.0), Point2F(5.0, 3.0), Point2F(5.5, 3.0), Point2F(6.0, 3.0),
+                         Point2F(4.0, 3.5), Point2F(4.5, 3.5), Point2F(5.0, 3.5), Point2F(5.5, 3.5), Point2F(6.0, 3.5),
+                         Point2F(4.0, 4.0), Point2F(4.5, 4.0), Point2F(5.0, 4.0), Point2F(5.5, 4.0), Point2F(6.0, 4.0)};
 
-    testInsert(Rect(Point2D(0., 0.), Point2D(6.0, 6.0)), // areaRect
+    testInsert(Rect(Point2F(0., 0.), Point2F(6.0, 6.0)), // areaRect
                2.0,                                      // radius
                0.001,                                    // accuracy
                points,                                   // points
@@ -751,15 +751,15 @@ void NeighboursSearchTestSuite::insertPointsIntoBoxesRightCenterBox()
 
 void NeighboursSearchTestSuite::insertPointsIntoBoxesBottomLineBox()
 {
-    TestPoints points = {Point2D(0.0, 0.0), Point2D(1.0, 0.0), Point2D(2.0, 0.0), Point2D(3.0, 0.0), Point2D(4.0, 0.0),
-                         Point2D(5.0, 0.0), Point2D(6.0, 0.0), Point2D(0.0, 1.0), Point2D(1.0, 1.0), Point2D(2.0, 1.0),
-                         Point2D(3.0, 1.0), Point2D(4.0, 1.0), Point2D(5.0, 1.0), Point2D(6.0, 1.0), Point2D(0.0, 2.0),
-                         Point2D(1.0, 2.0), Point2D(2.0, 2.0), Point2D(3.0, 2.0), Point2D(4.0, 2.0), Point2D(5.0, 2.0),
-                         Point2D(6.0, 2.0), Point2D(0.5, 0.5), Point2D(1.5, 0.5), Point2D(2.5, 0.5), Point2D(3.5, 0.5),
-                         Point2D(4.5, 0.5), Point2D(5.5, 0.5), Point2D(0.5, 1.5), Point2D(1.5, 1.5), Point2D(2.5, 1.5),
-                         Point2D(3.5, 1.5), Point2D(4.5, 1.5), Point2D(5.5, 1.5)};
+    TestPoints points = {Point2F(0.0, 0.0), Point2F(1.0, 0.0), Point2F(2.0, 0.0), Point2F(3.0, 0.0), Point2F(4.0, 0.0),
+                         Point2F(5.0, 0.0), Point2F(6.0, 0.0), Point2F(0.0, 1.0), Point2F(1.0, 1.0), Point2F(2.0, 1.0),
+                         Point2F(3.0, 1.0), Point2F(4.0, 1.0), Point2F(5.0, 1.0), Point2F(6.0, 1.0), Point2F(0.0, 2.0),
+                         Point2F(1.0, 2.0), Point2F(2.0, 2.0), Point2F(3.0, 2.0), Point2F(4.0, 2.0), Point2F(5.0, 2.0),
+                         Point2F(6.0, 2.0), Point2F(0.5, 0.5), Point2F(1.5, 0.5), Point2F(2.5, 0.5), Point2F(3.5, 0.5),
+                         Point2F(4.5, 0.5), Point2F(5.5, 0.5), Point2F(0.5, 1.5), Point2F(1.5, 1.5), Point2F(2.5, 1.5),
+                         Point2F(3.5, 1.5), Point2F(4.5, 1.5), Point2F(5.5, 1.5)};
 
-    testInsert(Rect(Point2D(0., 0.), Point2D(6.0, 6.0)), // areaRect
+    testInsert(Rect(Point2F(0., 0.), Point2F(6.0, 6.0)), // areaRect
                2.0,                                      // radius
                0.001,                                    // accuracy
                points,                                   // points
@@ -777,15 +777,15 @@ void NeighboursSearchTestSuite::insertPointsIntoBoxesBottomLineBox()
 
 void NeighboursSearchTestSuite::insertPointsIntoBoxesLeftLineBox()
 {
-    TestPoints points = {Point2D(0.0, 0.0), Point2D(0.0, 1.0), Point2D(0.0, 2.0), Point2D(0.0, 3.0), Point2D(0.0, 4.0),
-                         Point2D(0.0, 5.0), Point2D(0.0, 6.0), Point2D(1.0, 0.0), Point2D(1.0, 1.0), Point2D(1.0, 2.0),
-                         Point2D(1.0, 3.0), Point2D(1.0, 4.0), Point2D(1.0, 5.0), Point2D(1.0, 6.0), Point2D(2.0, 0.0),
-                         Point2D(2.0, 1.0), Point2D(2.0, 2.0), Point2D(2.0, 3.0), Point2D(2.0, 4.0), Point2D(2.0, 5.0),
-                         Point2D(2.0, 6.0), Point2D(0.5, 0.5), Point2D(0.5, 1.5), Point2D(0.5, 2.5), Point2D(0.5, 3.5),
-                         Point2D(0.5, 4.5), Point2D(0.5, 5.5), Point2D(1.5, 0.5), Point2D(1.5, 1.5), Point2D(1.5, 2.5),
-                         Point2D(1.5, 3.5), Point2D(1.5, 4.5), Point2D(1.5, 5.5)};
+    TestPoints points = {Point2F(0.0, 0.0), Point2F(0.0, 1.0), Point2F(0.0, 2.0), Point2F(0.0, 3.0), Point2F(0.0, 4.0),
+                         Point2F(0.0, 5.0), Point2F(0.0, 6.0), Point2F(1.0, 0.0), Point2F(1.0, 1.0), Point2F(1.0, 2.0),
+                         Point2F(1.0, 3.0), Point2F(1.0, 4.0), Point2F(1.0, 5.0), Point2F(1.0, 6.0), Point2F(2.0, 0.0),
+                         Point2F(2.0, 1.0), Point2F(2.0, 2.0), Point2F(2.0, 3.0), Point2F(2.0, 4.0), Point2F(2.0, 5.0),
+                         Point2F(2.0, 6.0), Point2F(0.5, 0.5), Point2F(0.5, 1.5), Point2F(0.5, 2.5), Point2F(0.5, 3.5),
+                         Point2F(0.5, 4.5), Point2F(0.5, 5.5), Point2F(1.5, 0.5), Point2F(1.5, 1.5), Point2F(1.5, 2.5),
+                         Point2F(1.5, 3.5), Point2F(1.5, 4.5), Point2F(1.5, 5.5)};
 
-    testInsert(Rect(Point2D(0., 0.), Point2D(6.0, 6.0)), // areaRect
+    testInsert(Rect(Point2F(0., 0.), Point2F(6.0, 6.0)), // areaRect
                2.0,                                      // radius
                0.001,                                    // accuracy
                points,                                   // points
@@ -803,15 +803,15 @@ void NeighboursSearchTestSuite::insertPointsIntoBoxesLeftLineBox()
 
 void NeighboursSearchTestSuite::insertPointsIntoBoxesTopLineBox()
 {
-    TestPoints points = {Point2D(0.0, 4.0), Point2D(1.0, 4.0), Point2D(2.0, 4.0), Point2D(3.0, 4.0), Point2D(4.0, 4.0),
-                         Point2D(5.0, 4.0), Point2D(6.0, 4.0), Point2D(0.0, 5.0), Point2D(1.0, 5.0), Point2D(2.0, 5.0),
-                         Point2D(3.0, 5.0), Point2D(4.0, 5.0), Point2D(5.0, 5.0), Point2D(6.0, 5.0), Point2D(0.0, 6.0),
-                         Point2D(1.0, 6.0), Point2D(2.0, 6.0), Point2D(3.0, 6.0), Point2D(4.0, 6.0), Point2D(5.0, 6.0),
-                         Point2D(6.0, 6.0), Point2D(0.5, 4.5), Point2D(1.5, 4.5), Point2D(2.5, 4.5), Point2D(3.5, 4.5),
-                         Point2D(4.5, 4.5), Point2D(5.5, 4.5), Point2D(0.5, 5.5), Point2D(1.5, 5.5), Point2D(2.5, 5.5),
-                         Point2D(3.5, 5.5), Point2D(4.5, 5.5), Point2D(5.5, 5.5)};
+    TestPoints points = {Point2F(0.0, 4.0), Point2F(1.0, 4.0), Point2F(2.0, 4.0), Point2F(3.0, 4.0), Point2F(4.0, 4.0),
+                         Point2F(5.0, 4.0), Point2F(6.0, 4.0), Point2F(0.0, 5.0), Point2F(1.0, 5.0), Point2F(2.0, 5.0),
+                         Point2F(3.0, 5.0), Point2F(4.0, 5.0), Point2F(5.0, 5.0), Point2F(6.0, 5.0), Point2F(0.0, 6.0),
+                         Point2F(1.0, 6.0), Point2F(2.0, 6.0), Point2F(3.0, 6.0), Point2F(4.0, 6.0), Point2F(5.0, 6.0),
+                         Point2F(6.0, 6.0), Point2F(0.5, 4.5), Point2F(1.5, 4.5), Point2F(2.5, 4.5), Point2F(3.5, 4.5),
+                         Point2F(4.5, 4.5), Point2F(5.5, 4.5), Point2F(0.5, 5.5), Point2F(1.5, 5.5), Point2F(2.5, 5.5),
+                         Point2F(3.5, 5.5), Point2F(4.5, 5.5), Point2F(5.5, 5.5)};
 
-    testInsert(Rect(Point2D(0., 0.), Point2D(6.0, 6.0)), // areaRect
+    testInsert(Rect(Point2F(0., 0.), Point2F(6.0, 6.0)), // areaRect
                2.0,                                      // radius
                0.001,                                    // accuracy
                points,                                   // points
@@ -829,15 +829,15 @@ void NeighboursSearchTestSuite::insertPointsIntoBoxesTopLineBox()
 
 void NeighboursSearchTestSuite::insertPointsIntoBoxesRightLineBox()
 {
-    TestPoints points = {Point2D(4.0, 0.0), Point2D(4.0, 1.0), Point2D(4.0, 2.0), Point2D(4.0, 3.0), Point2D(4.0, 4.0),
-                         Point2D(4.0, 5.0), Point2D(4.0, 6.0), Point2D(5.0, 0.0), Point2D(5.0, 1.0), Point2D(5.0, 2.0),
-                         Point2D(5.0, 3.0), Point2D(5.0, 4.0), Point2D(5.0, 5.0), Point2D(5.0, 6.0), Point2D(6.0, 0.0),
-                         Point2D(6.0, 1.0), Point2D(6.0, 2.0), Point2D(6.0, 3.0), Point2D(6.0, 4.0), Point2D(6.0, 5.0),
-                         Point2D(6.0, 6.0), Point2D(4.5, 0.5), Point2D(4.5, 1.5), Point2D(4.5, 2.5), Point2D(4.5, 3.5),
-                         Point2D(4.5, 4.5), Point2D(4.5, 5.5), Point2D(5.5, 0.5), Point2D(5.5, 1.5), Point2D(5.5, 2.5),
-                         Point2D(5.5, 3.5), Point2D(5.5, 4.5), Point2D(5.5, 5.5)};
+    TestPoints points = {Point2F(4.0, 0.0), Point2F(4.0, 1.0), Point2F(4.0, 2.0), Point2F(4.0, 3.0), Point2F(4.0, 4.0),
+                         Point2F(4.0, 5.0), Point2F(4.0, 6.0), Point2F(5.0, 0.0), Point2F(5.0, 1.0), Point2F(5.0, 2.0),
+                         Point2F(5.0, 3.0), Point2F(5.0, 4.0), Point2F(5.0, 5.0), Point2F(5.0, 6.0), Point2F(6.0, 0.0),
+                         Point2F(6.0, 1.0), Point2F(6.0, 2.0), Point2F(6.0, 3.0), Point2F(6.0, 4.0), Point2F(6.0, 5.0),
+                         Point2F(6.0, 6.0), Point2F(4.5, 0.5), Point2F(4.5, 1.5), Point2F(4.5, 2.5), Point2F(4.5, 3.5),
+                         Point2F(4.5, 4.5), Point2F(4.5, 5.5), Point2F(5.5, 0.5), Point2F(5.5, 1.5), Point2F(5.5, 2.5),
+                         Point2F(5.5, 3.5), Point2F(5.5, 4.5), Point2F(5.5, 5.5)};
 
-    testInsert(Rect(Point2D(0., 0.), Point2D(6.0, 6.0)), // areaRect
+    testInsert(Rect(Point2F(0., 0.), Point2F(6.0, 6.0)), // areaRect
                2.0,                                      // radius
                0.001,                                    // accuracy
                points,                                   // points
@@ -855,12 +855,12 @@ void NeighboursSearchTestSuite::insertPointsIntoBoxesRightLineBox()
 
 void NeighboursSearchTestSuite::insertPointsIntoBoxes3x2()
 {
-    TestPoints points = {Point2D(0.0, 0.0), Point2D(1.0, 0.0), Point2D(2.0, 0.0), Point2D(3.0, 0.0), Point2D(0.0, 1.0),
-                         Point2D(1.0, 1.0), Point2D(2.0, 1.0), Point2D(3.0, 1.0), Point2D(0.0, 2.0), Point2D(1.0, 2.0),
-                         Point2D(2.0, 2.0), Point2D(3.0, 2.0), Point2D(0.5, 0.5), Point2D(1.5, 0.5), Point2D(2.5, 0.5),
-                         Point2D(0.5, 1.5), Point2D(1.5, 1.5), Point2D(2.5, 1.5)};
+    TestPoints points = {Point2F(0.0, 0.0), Point2F(1.0, 0.0), Point2F(2.0, 0.0), Point2F(3.0, 0.0), Point2F(0.0, 1.0),
+                         Point2F(1.0, 1.0), Point2F(2.0, 1.0), Point2F(3.0, 1.0), Point2F(0.0, 2.0), Point2F(1.0, 2.0),
+                         Point2F(2.0, 2.0), Point2F(3.0, 2.0), Point2F(0.5, 0.5), Point2F(1.5, 0.5), Point2F(2.5, 0.5),
+                         Point2F(0.5, 1.5), Point2F(1.5, 1.5), Point2F(2.5, 1.5)};
 
-    testInsert(Rect(Point2D(0.0, 0.0), Point2D(3.0, 2.0)),                                  // areaRect
+    testInsert(Rect(Point2F(0.0, 0.0), Point2F(3.0, 2.0)),                                  // areaRect
                1.0,                                                                         // radius
                0.001,                                                                       // accuracy
                points,                                                                      // points
@@ -870,13 +870,13 @@ void NeighboursSearchTestSuite::insertPointsIntoBoxes3x2()
 
 void NeighboursSearchTestSuite::insertPointsIntoBoxes4x2()
 {
-    TestPoints points = {Point2D(0.0, 0.0), Point2D(1.0, 0.0), Point2D(2.0, 0.0), Point2D(3.0, 0.0), Point2D(4.0, 0.0),
-                         Point2D(0.0, 1.0), Point2D(1.0, 1.0), Point2D(2.0, 1.0), Point2D(3.0, 1.0), Point2D(4.0, 1.0),
-                         Point2D(0.0, 2.0), Point2D(1.0, 2.0), Point2D(2.0, 2.0), Point2D(3.0, 2.0), Point2D(4.0, 2.0),
-                         Point2D(0.5, 0.5), Point2D(1.5, 0.5), Point2D(2.5, 0.5), Point2D(3.5, 0.5), Point2D(0.5, 1.5),
-                         Point2D(1.5, 1.5), Point2D(2.5, 1.5), Point2D(3.5, 1.5)};
+    TestPoints points = {Point2F(0.0, 0.0), Point2F(1.0, 0.0), Point2F(2.0, 0.0), Point2F(3.0, 0.0), Point2F(4.0, 0.0),
+                         Point2F(0.0, 1.0), Point2F(1.0, 1.0), Point2F(2.0, 1.0), Point2F(3.0, 1.0), Point2F(4.0, 1.0),
+                         Point2F(0.0, 2.0), Point2F(1.0, 2.0), Point2F(2.0, 2.0), Point2F(3.0, 2.0), Point2F(4.0, 2.0),
+                         Point2F(0.5, 0.5), Point2F(1.5, 0.5), Point2F(2.5, 0.5), Point2F(3.5, 0.5), Point2F(0.5, 1.5),
+                         Point2F(1.5, 1.5), Point2F(2.5, 1.5), Point2F(3.5, 1.5)};
 
-    testInsert(Rect(Point2D(0.0, 0.0), Point2D(4.0, 2.0)), // areaRect
+    testInsert(Rect(Point2F(0.0, 0.0), Point2F(4.0, 2.0)), // areaRect
                1.0,                                        // radius
                0.001,                                      // accuracy
                points,                                     // points
@@ -893,13 +893,13 @@ void NeighboursSearchTestSuite::insertPointsIntoBoxes4x2()
 
 void NeighboursSearchTestSuite::insertPointsIntoBoxes2x4()
 {
-    TestPoints points = {Point2D(0.0, 0.0), Point2D(1.0, 0.0), Point2D(2.0, 0.0), Point2D(0.0, 1.0), Point2D(1.0, 1.0),
-                         Point2D(2.0, 1.0), Point2D(0.0, 2.0), Point2D(1.0, 2.0), Point2D(2.0, 2.0), Point2D(0.0, 3.0),
-                         Point2D(1.0, 3.0), Point2D(2.0, 3.0), Point2D(0.0, 4.0), Point2D(1.0, 4.0), Point2D(2.0, 4.0),
-                         Point2D(0.5, 0.5), Point2D(1.5, 0.5), Point2D(0.5, 1.5), Point2D(1.5, 1.5), Point2D(0.5, 2.5),
-                         Point2D(1.5, 2.5), Point2D(0.5, 3.5), Point2D(1.5, 3.5)};
+    TestPoints points = {Point2F(0.0, 0.0), Point2F(1.0, 0.0), Point2F(2.0, 0.0), Point2F(0.0, 1.0), Point2F(1.0, 1.0),
+                         Point2F(2.0, 1.0), Point2F(0.0, 2.0), Point2F(1.0, 2.0), Point2F(2.0, 2.0), Point2F(0.0, 3.0),
+                         Point2F(1.0, 3.0), Point2F(2.0, 3.0), Point2F(0.0, 4.0), Point2F(1.0, 4.0), Point2F(2.0, 4.0),
+                         Point2F(0.5, 0.5), Point2F(1.5, 0.5), Point2F(0.5, 1.5), Point2F(1.5, 1.5), Point2F(0.5, 2.5),
+                         Point2F(1.5, 2.5), Point2F(0.5, 3.5), Point2F(1.5, 3.5)};
 
-    testInsert(Rect(Point2D(0.0, 0.0), Point2D(2.0, 4.0)), // areaRect
+    testInsert(Rect(Point2F(0.0, 0.0), Point2F(2.0, 4.0)), // areaRect
                1.0,                                        // radius
                0.001,                                      // accuracy
                points,                                     // points
@@ -917,21 +917,21 @@ void NeighboursSearchTestSuite::insertPointsIntoBoxes2x4()
 void NeighboursSearchTestSuite::insertPointsIntoBoxes8x3()
 {
     TestPoints points = {
-        Point2D(0.0, 0.0), Point2D(1.0, 0.0), Point2D(2.0, 0.0), Point2D(3.0, 0.0), Point2D(4.0, 0.0),
-        Point2D(5.0, 0.0), Point2D(6.0, 0.0), Point2D(7.0, 0.0), Point2D(8.0, 0.0), Point2D(0.0, 1.0),
-        Point2D(1.0, 1.0), Point2D(2.0, 1.0), Point2D(3.0, 1.0), Point2D(4.0, 1.0), Point2D(5.0, 1.0),
-        Point2D(6.0, 1.0), Point2D(7.0, 1.0), Point2D(8.0, 1.0), Point2D(0.0, 2.0), Point2D(1.0, 2.0),
-        Point2D(2.0, 2.0), Point2D(3.0, 2.0), Point2D(4.0, 2.0), Point2D(5.0, 2.0), Point2D(6.0, 2.0),
-        Point2D(7.0, 2.0), Point2D(8.0, 2.0), Point2D(0.0, 3.0), Point2D(1.0, 3.0), Point2D(2.0, 3.0),
-        Point2D(3.0, 3.0), Point2D(4.0, 3.0), Point2D(5.0, 3.0), Point2D(6.0, 3.0), Point2D(7.0, 3.0),
-        Point2D(8.0, 3.0), Point2D(0.5, 0.5), Point2D(1.5, 0.5), Point2D(2.5, 0.5), Point2D(3.5, 0.5),
-        Point2D(4.5, 0.5), Point2D(5.5, 0.5), Point2D(6.5, 0.5), Point2D(7.5, 0.5), Point2D(0.5, 1.5),
-        Point2D(1.5, 1.5), Point2D(2.5, 1.5), Point2D(3.5, 1.5), Point2D(4.5, 1.5), Point2D(5.5, 1.5),
-        Point2D(6.5, 1.5), Point2D(7.5, 1.5), Point2D(0.5, 2.5), Point2D(1.5, 2.5), Point2D(2.5, 2.5),
-        Point2D(3.5, 2.5), Point2D(4.5, 2.5), Point2D(5.5, 2.5), Point2D(6.5, 2.5), Point2D(7.5, 2.5),
+        Point2F(0.0, 0.0), Point2F(1.0, 0.0), Point2F(2.0, 0.0), Point2F(3.0, 0.0), Point2F(4.0, 0.0),
+        Point2F(5.0, 0.0), Point2F(6.0, 0.0), Point2F(7.0, 0.0), Point2F(8.0, 0.0), Point2F(0.0, 1.0),
+        Point2F(1.0, 1.0), Point2F(2.0, 1.0), Point2F(3.0, 1.0), Point2F(4.0, 1.0), Point2F(5.0, 1.0),
+        Point2F(6.0, 1.0), Point2F(7.0, 1.0), Point2F(8.0, 1.0), Point2F(0.0, 2.0), Point2F(1.0, 2.0),
+        Point2F(2.0, 2.0), Point2F(3.0, 2.0), Point2F(4.0, 2.0), Point2F(5.0, 2.0), Point2F(6.0, 2.0),
+        Point2F(7.0, 2.0), Point2F(8.0, 2.0), Point2F(0.0, 3.0), Point2F(1.0, 3.0), Point2F(2.0, 3.0),
+        Point2F(3.0, 3.0), Point2F(4.0, 3.0), Point2F(5.0, 3.0), Point2F(6.0, 3.0), Point2F(7.0, 3.0),
+        Point2F(8.0, 3.0), Point2F(0.5, 0.5), Point2F(1.5, 0.5), Point2F(2.5, 0.5), Point2F(3.5, 0.5),
+        Point2F(4.5, 0.5), Point2F(5.5, 0.5), Point2F(6.5, 0.5), Point2F(7.5, 0.5), Point2F(0.5, 1.5),
+        Point2F(1.5, 1.5), Point2F(2.5, 1.5), Point2F(3.5, 1.5), Point2F(4.5, 1.5), Point2F(5.5, 1.5),
+        Point2F(6.5, 1.5), Point2F(7.5, 1.5), Point2F(0.5, 2.5), Point2F(1.5, 2.5), Point2F(2.5, 2.5),
+        Point2F(3.5, 2.5), Point2F(4.5, 2.5), Point2F(5.5, 2.5), Point2F(6.5, 2.5), Point2F(7.5, 2.5),
     };
 
-    testInsert(Rect(Point2D(0.0, 0.0), Point2D(8.0, 3.0)),                               // areaRect
+    testInsert(Rect(Point2F(0.0, 0.0), Point2F(8.0, 3.0)),                               // areaRect
                1.0,                                                                      // radius
                0.001,                                                                    // accuracy
                points,                                                                   // points
@@ -946,34 +946,34 @@ void NeighboursSearchTestSuite::insertPointsIntoBoxes8x3()
 
 void NeighboursSearchTestSuite::insertPointsIntoBoxes9x6()
 {
-    TestPoints points = {Point2D(0.0, 0.0), Point2D(1.0, 0.0), Point2D(2.0, 0.0), Point2D(3.0, 0.0), Point2D(4.0, 0.0),
-                         Point2D(5.0, 0.0), Point2D(6.0, 0.0), Point2D(7.0, 0.0), Point2D(8.0, 0.0), Point2D(9.0, 0.0),
-                         Point2D(0.0, 1.0), Point2D(1.0, 1.0), Point2D(2.0, 1.0), Point2D(3.0, 1.0), Point2D(4.0, 1.0),
-                         Point2D(5.0, 1.0), Point2D(6.0, 1.0), Point2D(7.0, 1.0), Point2D(8.0, 1.0), Point2D(9.0, 1.0),
-                         Point2D(0.0, 2.0), Point2D(1.0, 2.0), Point2D(2.0, 2.0), Point2D(3.0, 2.0), Point2D(4.0, 2.0),
-                         Point2D(5.0, 2.0), Point2D(6.0, 2.0), Point2D(7.0, 2.0), Point2D(8.0, 2.0), Point2D(9.0, 2.0),
-                         Point2D(0.0, 3.0), Point2D(1.0, 3.0), Point2D(2.0, 3.0), Point2D(3.0, 3.0), Point2D(4.0, 3.0),
-                         Point2D(5.0, 3.0), Point2D(6.0, 3.0), Point2D(7.0, 3.0), Point2D(8.0, 3.0), Point2D(9.0, 3.0),
-                         Point2D(0.0, 4.0), Point2D(1.0, 4.0), Point2D(2.0, 4.0), Point2D(3.0, 4.0), Point2D(4.0, 4.0),
-                         Point2D(5.0, 4.0), Point2D(6.0, 4.0), Point2D(7.0, 4.0), Point2D(8.0, 4.0), Point2D(9.0, 4.0),
-                         Point2D(0.0, 5.0), Point2D(1.0, 5.0), Point2D(2.0, 5.0), Point2D(3.0, 5.0), Point2D(4.0, 5.0),
-                         Point2D(5.0, 5.0), Point2D(6.0, 5.0), Point2D(7.0, 5.0), Point2D(8.0, 5.0), Point2D(9.0, 5.0),
-                         Point2D(0.0, 6.0), Point2D(1.0, 6.0), Point2D(2.0, 6.0), Point2D(3.0, 6.0), Point2D(4.0, 6.0),
-                         Point2D(5.0, 6.0), Point2D(6.0, 6.0), Point2D(7.0, 6.0), Point2D(8.0, 6.0), Point2D(9.0, 6.0),
+    TestPoints points = {Point2F(0.0, 0.0), Point2F(1.0, 0.0), Point2F(2.0, 0.0), Point2F(3.0, 0.0), Point2F(4.0, 0.0),
+                         Point2F(5.0, 0.0), Point2F(6.0, 0.0), Point2F(7.0, 0.0), Point2F(8.0, 0.0), Point2F(9.0, 0.0),
+                         Point2F(0.0, 1.0), Point2F(1.0, 1.0), Point2F(2.0, 1.0), Point2F(3.0, 1.0), Point2F(4.0, 1.0),
+                         Point2F(5.0, 1.0), Point2F(6.0, 1.0), Point2F(7.0, 1.0), Point2F(8.0, 1.0), Point2F(9.0, 1.0),
+                         Point2F(0.0, 2.0), Point2F(1.0, 2.0), Point2F(2.0, 2.0), Point2F(3.0, 2.0), Point2F(4.0, 2.0),
+                         Point2F(5.0, 2.0), Point2F(6.0, 2.0), Point2F(7.0, 2.0), Point2F(8.0, 2.0), Point2F(9.0, 2.0),
+                         Point2F(0.0, 3.0), Point2F(1.0, 3.0), Point2F(2.0, 3.0), Point2F(3.0, 3.0), Point2F(4.0, 3.0),
+                         Point2F(5.0, 3.0), Point2F(6.0, 3.0), Point2F(7.0, 3.0), Point2F(8.0, 3.0), Point2F(9.0, 3.0),
+                         Point2F(0.0, 4.0), Point2F(1.0, 4.0), Point2F(2.0, 4.0), Point2F(3.0, 4.0), Point2F(4.0, 4.0),
+                         Point2F(5.0, 4.0), Point2F(6.0, 4.0), Point2F(7.0, 4.0), Point2F(8.0, 4.0), Point2F(9.0, 4.0),
+                         Point2F(0.0, 5.0), Point2F(1.0, 5.0), Point2F(2.0, 5.0), Point2F(3.0, 5.0), Point2F(4.0, 5.0),
+                         Point2F(5.0, 5.0), Point2F(6.0, 5.0), Point2F(7.0, 5.0), Point2F(8.0, 5.0), Point2F(9.0, 5.0),
+                         Point2F(0.0, 6.0), Point2F(1.0, 6.0), Point2F(2.0, 6.0), Point2F(3.0, 6.0), Point2F(4.0, 6.0),
+                         Point2F(5.0, 6.0), Point2F(6.0, 6.0), Point2F(7.0, 6.0), Point2F(8.0, 6.0), Point2F(9.0, 6.0),
 
-                         Point2D(0.5, 0.5), Point2D(1.5, 0.5), Point2D(2.5, 0.5), Point2D(3.5, 0.5), Point2D(4.5, 0.5),
-                         Point2D(5.5, 0.5), Point2D(6.5, 0.5), Point2D(7.5, 0.5), Point2D(8.5, 0.5), Point2D(0.5, 1.5),
-                         Point2D(1.5, 1.5), Point2D(2.5, 1.5), Point2D(3.5, 1.5), Point2D(4.5, 1.5), Point2D(5.5, 1.5),
-                         Point2D(6.5, 1.5), Point2D(7.5, 1.5), Point2D(8.5, 1.5), Point2D(0.5, 2.5), Point2D(1.5, 2.5),
-                         Point2D(2.5, 2.5), Point2D(3.5, 2.5), Point2D(4.5, 2.5), Point2D(5.5, 2.5), Point2D(6.5, 2.5),
-                         Point2D(7.5, 2.5), Point2D(8.5, 2.5), Point2D(0.5, 3.5), Point2D(1.5, 3.5), Point2D(2.5, 3.5),
-                         Point2D(3.5, 3.5), Point2D(4.5, 3.5), Point2D(5.5, 3.5), Point2D(6.5, 3.5), Point2D(7.5, 3.5),
-                         Point2D(8.5, 3.5), Point2D(0.5, 4.5), Point2D(1.5, 4.5), Point2D(2.5, 4.5), Point2D(3.5, 4.5),
-                         Point2D(4.5, 4.5), Point2D(5.5, 4.5), Point2D(6.5, 4.5), Point2D(7.5, 4.5), Point2D(8.5, 4.5),
-                         Point2D(0.5, 5.5), Point2D(1.5, 5.5), Point2D(2.5, 5.5), Point2D(3.5, 5.5), Point2D(4.5, 5.5),
-                         Point2D(5.5, 5.5), Point2D(6.5, 5.5), Point2D(7.5, 5.5), Point2D(8.5, 5.5)};
+                         Point2F(0.5, 0.5), Point2F(1.5, 0.5), Point2F(2.5, 0.5), Point2F(3.5, 0.5), Point2F(4.5, 0.5),
+                         Point2F(5.5, 0.5), Point2F(6.5, 0.5), Point2F(7.5, 0.5), Point2F(8.5, 0.5), Point2F(0.5, 1.5),
+                         Point2F(1.5, 1.5), Point2F(2.5, 1.5), Point2F(3.5, 1.5), Point2F(4.5, 1.5), Point2F(5.5, 1.5),
+                         Point2F(6.5, 1.5), Point2F(7.5, 1.5), Point2F(8.5, 1.5), Point2F(0.5, 2.5), Point2F(1.5, 2.5),
+                         Point2F(2.5, 2.5), Point2F(3.5, 2.5), Point2F(4.5, 2.5), Point2F(5.5, 2.5), Point2F(6.5, 2.5),
+                         Point2F(7.5, 2.5), Point2F(8.5, 2.5), Point2F(0.5, 3.5), Point2F(1.5, 3.5), Point2F(2.5, 3.5),
+                         Point2F(3.5, 3.5), Point2F(4.5, 3.5), Point2F(5.5, 3.5), Point2F(6.5, 3.5), Point2F(7.5, 3.5),
+                         Point2F(8.5, 3.5), Point2F(0.5, 4.5), Point2F(1.5, 4.5), Point2F(2.5, 4.5), Point2F(3.5, 4.5),
+                         Point2F(4.5, 4.5), Point2F(5.5, 4.5), Point2F(6.5, 4.5), Point2F(7.5, 4.5), Point2F(8.5, 4.5),
+                         Point2F(0.5, 5.5), Point2F(1.5, 5.5), Point2F(2.5, 5.5), Point2F(3.5, 5.5), Point2F(4.5, 5.5),
+                         Point2F(5.5, 5.5), Point2F(6.5, 5.5), Point2F(7.5, 5.5), Point2F(8.5, 5.5)};
 
-    testInsert(Rect(Point2D(0.0, 0.0), Point2D(9.0, 6.0)), // areaRect
+    testInsert(Rect(Point2F(0.0, 0.0), Point2F(9.0, 6.0)), // areaRect
                1.0,                                        // radius
                0.001,                                      // accuracy
                points,                                     // points
@@ -1003,12 +1003,12 @@ void NeighboursSearchTestSuite::insertPointsIntoBoxes9x6()
 
 void NeighboursSearchTestSuite::findNearbyBoxesTwoByTwo()
 {
-    Rect rect(Point2D(0., 0.), Point2D(4.0, 4.0));
+    Rect rect(Point2F(0., 0.), Point2F(4.0, 4.0));
     Area area(rect);
 
     const VectorOfSizetVectors expectedNearbyBoxes = {{2, 1, 3}, {3, 0, 2}, {0, 3, 1}, {1, 2, 0}};
 
-    NeighboursSearch<Point2DVector> ns(area, 2.0, 0.001);
+    NeighboursSearch<Point3FVector> ns(area, 2.0, 0.001);
 
     ASSERT_EQ(ns.m_boxes.size(), ns.m_nearbyBoxes.size())
         << "The amount of boxes have to be equal in m_boxes and m_nearbyBoxes";
@@ -1022,13 +1022,13 @@ void NeighboursSearchTestSuite::findNearbyBoxesTwoByTwo()
 
 void NeighboursSearchTestSuite::findNearbyBoxesFourByTwo()
 {
-    Rect rect(Point2D(0., 0.), Point2D(2.0, 4.0));
+    Rect rect(Point2F(0., 0.), Point2F(2.0, 4.0));
     Area area(rect);
 
     const VectorOfSizetVectors expectedNearbyBoxes = {
         {2, 1, 3}, {3, 0, 2}, {0, 4, 3, 1, 5}, {1, 5, 2, 0, 4}, {2, 6, 5, 3, 7}, {3, 7, 4, 2, 6}, {4, 7, 5}, {5, 6, 4}};
 
-    NeighboursSearch<Point2DVector> ns(area, 1.0, 0.001);
+    NeighboursSearch<Point3FVector> ns(area, 1.0, 0.001);
 
     ASSERT_EQ(ns.m_boxes.size(), ns.m_nearbyBoxes.size())
         << "The amount of boxes have to be equal in m_boxes and m_nearbyBoxes";
@@ -1042,7 +1042,7 @@ void NeighboursSearchTestSuite::findNearbyBoxesFourByTwo()
 
 void NeighboursSearchTestSuite::findNearbyBoxesFourByFour()
 {
-    Rect rect(Point2D(0., 0.), Point2D(4.0, 4.0));
+    Rect rect(Point2F(0., 0.), Point2F(4.0, 4.0));
     Area area(rect);
 
     const VectorOfSizetVectors expectedNearbyBoxes = {{4, 1, 5},
@@ -1062,7 +1062,7 @@ void NeighboursSearchTestSuite::findNearbyBoxesFourByFour()
                                                       {10, 13, 15, 9, 11},
                                                       {11, 14, 10}};
 
-    NeighboursSearch<Point2DVector> ns(area, 1.0, 0.001);
+    NeighboursSearch<Point3FVector> ns(area, 1.0, 0.001);
 
     ASSERT_EQ(ns.m_boxes.size(), ns.m_nearbyBoxes.size())
         << "The amount of boxes have to be equal in m_boxes and m_nearbyBoxes";
@@ -1076,7 +1076,7 @@ void NeighboursSearchTestSuite::findNearbyBoxesFourByFour()
 
 void NeighboursSearchTestSuite::findNearbyBoxesFourByThree()
 {
-    Rect rect(Point2D(0., 0.), Point2D(3.0, 4.0));
+    Rect rect(Point2F(0., 0.), Point2F(3.0, 4.0));
     Area area(rect);
 
     const VectorOfSizetVectors expectedNearbyBoxes = {{3, 1, 4},
@@ -1092,7 +1092,7 @@ void NeighboursSearchTestSuite::findNearbyBoxesFourByThree()
                                                       {7, 9, 11, 6, 8},
                                                       {8, 10, 7}};
 
-    NeighboursSearch<Point2DVector> ns(area, 1.0, 0.001);
+    NeighboursSearch<Point3FVector> ns(area, 1.0, 0.001);
 
     EXPECT_EQ(ns.m_boxes.size(), ns.m_nearbyBoxes.size())
         << "The amount of boxes have to be equal in m_boxes and m_nearbyBoxes";
@@ -1106,14 +1106,14 @@ void NeighboursSearchTestSuite::findNearbyBoxesFourByThree()
 
 void NeighboursSearchTestSuite::findNearbyBoxesThreeByThree()
 {
-    Rect rect(Point2D(0., 0.), Point2D(6.0, 6.0));
+    Rect rect(Point2F(0., 0.), Point2F(6.0, 6.0));
     Area area(rect);
 
     const VectorOfSizetVectors expectedNearbyBoxes = {{3, 1, 4},       {4, 0, 2, 3, 5},          {5, 1, 4},
                                                       {0, 6, 4, 1, 7}, {1, 7, 3, 5, 0, 6, 2, 8}, {2, 8, 4, 1, 7},
                                                       {3, 7, 4},       {4, 6, 8, 3, 5},          {5, 7, 4}};
 
-    NeighboursSearch<Point2DVector> ns(area, 2.0, 0.001);
+    NeighboursSearch<Point3FVector> ns(area, 2.0, 0.001);
 
     ASSERT_EQ(ns.m_boxes.size(), ns.m_nearbyBoxes.size())
         << "The amount of boxes have to be equal in m_boxes and m_nearbyBoxes";
@@ -1126,9 +1126,9 @@ void NeighboursSearchTestSuite::findNearbyBoxesThreeByThree()
 }
 
 } // namespace TestEnvironment
-} // namespace SPHAlgorithms
+} // namespace SPHSDK
 
-using namespace SPHAlgorithms::TestEnvironment;
+using namespace SPHSDK::TestEnvironment;
 
 TEST(NeighboursSearchTestSuite, searchOneBox)
 {

--- a/algorithms/test/src/NeighboursSearchTestSuite.h
+++ b/algorithms/test/src/NeighboursSearchTestSuite.h
@@ -125,17 +125,17 @@ private:
         SPHAlgorithms::SizetVector neighbours;
     };
 
-    struct TestPoint3D
+    struct TestPoint3F
     {
-        TestPoint3D(SPHAlgorithms::Point3D _position) : position(_position) {}
+        TestPoint3F(SPHAlgorithms::Point3F _position) : position(_position) {}
 
-        SPHAlgorithms::Point3D position;
+        SPHAlgorithms::Point3F position;
 
         SPHAlgorithms::SizetVector neighbours;
     };
 
     using TestPoints = std::vector<TestPoint>;
-    using TestPoints3D = std::vector<TestPoint3D>;
+    using TestPoints3D = std::vector<TestPoint3F>;
 
     static void testSearch(/*in*/ const Rect& areaRect,
                            /*in*/ double radius,

--- a/algorithms/test/src/NeighboursSearchTestSuite.h
+++ b/algorithms/test/src/NeighboursSearchTestSuite.h
@@ -14,7 +14,7 @@
 #include "Point.h"
 #include "Area.h"
 
-namespace SPHAlgorithms
+namespace SPHSDK
 {
 
 struct Rect;
@@ -118,57 +118,57 @@ private:
 
     struct TestPoint
     {
-        TestPoint(SPHAlgorithms::Point2D _position) : position(_position) {}
+        TestPoint(Point2F _position) : position(_position) {}
 
-        SPHAlgorithms::Point2D position;
+        Point2F position;
 
-        SPHAlgorithms::SizetVector neighbours;
+        SizetVector neighbours;
     };
 
     struct TestPoint3F
     {
-        TestPoint3F(SPHAlgorithms::Point3F _position) : position(_position) {}
+        TestPoint3F(Point3F _position) : position(_position) {}
 
-        SPHAlgorithms::Point3F position;
+        Point3F position;
 
-        SPHAlgorithms::SizetVector neighbours;
+        SizetVector neighbours;
     };
 
     using TestPoints = std::vector<TestPoint>;
     using TestPoints3D = std::vector<TestPoint3F>;
 
     static void testSearch(/*in*/ const Rect& areaRect,
-                           /*in*/ double radius,
-                           /*in*/ double accuracy,
+                           /*in*/ FLOAT radius,
+                           /*in*/ FLOAT accuracy,
                            /*in*/ TestPoints &points,
                            /*in*/ const SizetVector& expectedBoxSizes,
                            /*in*/ const VectorOfSizetVectors& expectedNeighbours);
 
     static void testInsert(/*in*/ const Rect& areaRect,
-                           /*in*/ double radius,
-                           /*in*/ double accuracy,
+                           /*in*/ FLOAT radius,
+                           /*in*/ FLOAT accuracy,
                            /*in*/ TestPoints& points,
                            /*in*/ const SizetVector& expectedBoxSizes,
                            /*in*/ const VectorOfSizetVectors& expectedPointsInBoxes);
 
-    static void testSearch3D(const SPHAlgorithms::Cuboid&               cuboid,
-                           double                      radius,
-                           double                      accuracy,
+    static void testSearch3D(const Cuboid&               cuboid,
+                           FLOAT                      radius,
+                           FLOAT                      accuracy,
                            TestPoints3D&               points,
                            const SizetVector&          expectedBoxSizes,
                            const VectorOfSizetVectors& expectedBoxNeighbours,
                            const VectorOfSizetVectors& expectedPointNeighbours);
 
-    static void testInsert3D(const SPHAlgorithms::Cuboid&               cuboid,
-                           double                      radius,
-                           double                      accuracy,
+    static void testInsert3D(const Cuboid&               cuboid,
+                           FLOAT                      radius,
+                           FLOAT                      accuracy,
                            TestPoints3D&               points,
                            const SizetVector&          expectedBoxSizes,
                            const VectorOfSizetVectors& expectedPointsInBoxes);
 
 };
 
-} //TestEnvironment
-} //SPHAlgorithms
+} // namespace TestEnvironment
+} // namespace SPHSDK
 
 #endif // NEIGHBOURS_SEARCH_TEST_SUITE_H_96192C2023784EE0B4976A48A1A8779B

--- a/algorithms/test/src/ROperationsTestSuite.cpp
+++ b/algorithms/test/src/ROperationsTestSuite.cpp
@@ -12,7 +12,7 @@
 #include <gtest/gtest.h>
 #include <cmath>
 
-namespace SPHAlgorithms
+namespace SPHSDK
 {
 namespace TestEnvironment
 {
@@ -30,9 +30,9 @@ void ROperationsTestSuite::testDisjunction()
 }
 
 } // namespace TestEnvironment
-} // namespace SPHAlgorithms
+} // namespace SPHSDK
 
-using namespace SPHAlgorithms::TestEnvironment;
+using namespace SPHSDK::TestEnvironment;
 
 TEST(ROperationsTestSuite, testConjunction)
 {

--- a/algorithms/test/src/ROperationsTestSuite.h
+++ b/algorithms/test/src/ROperationsTestSuite.h
@@ -8,7 +8,7 @@
 #ifndef R_OPERATIONS_TEST_SUITE_H_76192C2023784EE0B4976A48A1A8779B
 #define R_OPERATIONS_TEST_SUITE_H_76192C2023784EE0B4976A48A1A8779B
 
-namespace SPHAlgorithms
+namespace SPHSDK
 {
 
 namespace TestEnvironment
@@ -23,7 +23,7 @@ public:
     static void testDisjunction();
 };
 
-} //TestEnvironment
-} //SPHAlgorithms
+} // namespace TestEnvironment
+} // namespace SPHSDK
 
 #endif // R_OPERATIONS_TEST_SUITE_H_76192C2023784EE0B4976A48A1A8779B

--- a/algorithms/test/src/VolumeTestSuite.cpp
+++ b/algorithms/test/src/VolumeTestSuite.cpp
@@ -8,7 +8,7 @@
 
 #include <gtest/gtest.h>
 
-namespace SPHAlgorithms::TestEnvironment
+namespace SPHSDK::TestEnvironment
 {
 
 void VolumeTestSuite::testDefaultCtor()
@@ -16,9 +16,9 @@ void VolumeTestSuite::testDefaultCtor()
   ASSERT_NO_THROW({ Volume v; });
 }
 
-} // namespace SPHAlgorithms::TestEnvironment
+} // namespace SPHSDK::TestEnvironment
 
-using namespace SPHAlgorithms::TestEnvironment;
+using namespace SPHSDK::TestEnvironment;
 
 TEST(VolumeTestSuite, testDefaultCtor)
 {

--- a/algorithms/test/src/VolumeTestSuite.h
+++ b/algorithms/test/src/VolumeTestSuite.h
@@ -5,7 +5,7 @@
 #ifndef SPH_SDK_ALGORITHMS_TEST_SRC_VOLUMETESTSUITE_H
 #define SPH_SDK_ALGORITHMS_TEST_SRC_VOLUMETESTSUITE_H
 
-namespace SPHAlgorithms::TestEnvironment
+namespace SPHSDK::TestEnvironment
 {
 
 class VolumeTestSuite
@@ -14,6 +14,6 @@ public:
     static void testDefaultCtor();
 };
 
-} // SPHAlgorithms::TestEnvironment
+} // namespace SPHSDK::TestEnvironment
 
 #endif // SPH_SDK_ALGORITHMS_TEST_SRC_VOLUMETESTSUITE_H

--- a/demo/src/Draw.cpp
+++ b/demo/src/Draw.cpp
@@ -27,16 +27,16 @@
 #include "sph/src/SPH.h"
 
 // Window dimensions
-float aspect_ratio = 1.;
+SPHSDK::FLOAT aspect_ratio = 1.;
 static int width = 900;
 static int height = 900;
 
-static float angle = 360;
+static SPHSDK::FLOAT angle = 360;
 static const GLfloat pointSize = 5.f;
 
 static SPHSDK::SPH sph;
 
-static SPHAlgorithms::Point3FVector mesh;
+static SPHSDK::Point3FVector mesh;
 
 struct SVertex
 {
@@ -77,7 +77,7 @@ void MyDisplay(void)
 
     sph.run();
 
-    const float cubeSize = static_cast<float>(SPHSDK::Config::CubeSize);
+    const SPHSDK::FLOAT cubeSize = static_cast<SPHSDK::FLOAT>(SPHSDK::Config::CubeSize);
 
     // Draw the obstacle
     glBegin(GL_TRIANGLES);
@@ -98,7 +98,7 @@ void MyDisplay(void)
         points[i].y = static_cast<GLfloat>(sph.particles[i].position.y);
         points[i].z = static_cast<GLfloat>(sph.particles[i].position.z);
 
-        const double velocity = sph.particles[i].velocity.calcNormSqr();
+        const SPHSDK::FLOAT velocity = sph.particles[i].velocity.calcNormSqr();
         // color depends on velocity
         if (velocity > SPHSDK::Config::SpeedTreshold / 2.)
         {
@@ -178,7 +178,7 @@ void updateGravity()
     //   |0   cos θ    −sin θ| |y| = |y cos θ − z sin θ| = |y'|
     //   |0   sin θ     cos θ| |z|   |y sin θ + z cos θ|   |z'|
     SPHSDK::Config::GravitationalAcceleration =
-        SPHAlgorithms::Point3F(SPHSDK::Config::InitialGravitationalAcceleration.x,
+        SPHSDK::Point3F(SPHSDK::Config::InitialGravitationalAcceleration.x,
                                SPHSDK::Config::InitialGravitationalAcceleration.y * cos(angle / 180 * M_PI) -
                                    SPHSDK::Config::InitialGravitationalAcceleration.z * sin(angle / 180 * M_PI),
                                SPHSDK::Config::InitialGravitationalAcceleration.y * sin(angle / 180 * M_PI) +
@@ -188,7 +188,7 @@ void updateGravity()
 void resize_callback(GLFWwindow* window, int width, int height)
 {
     glViewport(0, 0, width, height);
-    aspect_ratio = height ? width / (float) height : 1.f;
+    aspect_ratio = height ? width / (SPHSDK::FLOAT) height : 1.f;
 }
 
 
@@ -206,7 +206,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
             break;
         case GLFW_KEY_HOME:
             angle = 360.0;
-            SPHSDK::Config::GravitationalAcceleration = SPHAlgorithms::Point3F(0.0, 0.0, -9.82);
+            SPHSDK::Config::GravitationalAcceleration = SPHSDK::Point3F(0.0, 0.0, -9.82);
             break;
         case GLFW_KEY_ESCAPE:
             glfwSetWindowShouldClose(window, GLFW_TRUE);
@@ -216,10 +216,12 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
 
 void Draw::MainDraw(int argc, char** argv)
 {
-    static const std::function<float(float, float, float)> obstacle = SPHAlgorithms::Shapes::Pawn;
-    sph = SPHSDK::SPH(&obstacle);
+    using namespace SPHSDK;
 
-    mesh = SPHAlgorithms::MarchingCubes::generateMesh(obstacle);
+    static const std::function<FLOAT(FLOAT, FLOAT, FLOAT)> obstacle = Shapes::Pawn;
+    sph = SPH(&obstacle);
+
+    mesh = MarchingCubes::generateMesh(obstacle);
 
     // GLFW initialization
     if (!glfwInit()) {

--- a/demo/src/Draw.cpp
+++ b/demo/src/Draw.cpp
@@ -8,6 +8,7 @@
 #include "linmath.h"
 
 #include <iostream>
+#include <cstddef>
 #include <stdlib.h>
 #include <time.h>
 
@@ -92,36 +93,8 @@ void MyDisplay(void)
     glEnableClientState(GL_COLOR_ARRAY);
     glPointSize(pointSize);
 
-    for (size_t i = 0; i < sph.particles.size(); ++i)
-    {
-        points[i].x = static_cast<GLfloat>(sph.particles[i].position.x);
-        points[i].y = static_cast<GLfloat>(sph.particles[i].position.y);
-        points[i].z = static_cast<GLfloat>(sph.particles[i].position.z);
-
-        const SPHSDK::FLOAT velocity = sph.particles[i].velocity.calcNormSqr();
-        // color depends on velocity
-        if (velocity > SPHSDK::Config::SpeedTreshold / 2.)
-        {
-            points[i].r = 1.0f;
-            points[i].g = 0.0f;
-            points[i].b = 0.0f;
-        }
-        else if (velocity > SPHSDK::Config::SpeedTreshold / 4.)
-        {
-            points[i].r = 0.99f;
-            points[i].g = 0.7f;
-            points[i].b = 0.0f;
-        }
-        else
-        {
-            points[i].r = 0.0f;
-            points[i].g = 0.0f;
-            points[i].b = 1.0f;
-        }
-    }
-
-    glVertexPointer(3, GL_FLOAT, sizeof(SVertex), points.data());
-    glColorPointer(3, GL_FLOAT, sizeof(SVertex), &points[0].r);
+    glVertexPointer(3, GL_FLOAT, sizeof(SPHSDK::Particle), &sph.particles[0].position);
+    glColorPointer(3, GL_FLOAT, sizeof(SVertex), &sph.particles[0].colour);
     glDrawArrays(GL_POINTS, 0, SPHSDK::Config::ParticlesNumber);
 
     glDisableClientState(GL_COLOR_ARRAY);

--- a/demo/src/Draw.cpp
+++ b/demo/src/Draw.cpp
@@ -178,7 +178,7 @@ void updateGravity()
     //   |0   cos θ    −sin θ| |y| = |y cos θ − z sin θ| = |y'|
     //   |0   sin θ     cos θ| |z|   |y sin θ + z cos θ|   |z'|
     SPHSDK::Config::GravitationalAcceleration =
-        SPHAlgorithms::Point3D(SPHSDK::Config::InitialGravitationalAcceleration.x,
+        SPHAlgorithms::Point3F(SPHSDK::Config::InitialGravitationalAcceleration.x,
                                SPHSDK::Config::InitialGravitationalAcceleration.y * cos(angle / 180 * M_PI) -
                                    SPHSDK::Config::InitialGravitationalAcceleration.z * sin(angle / 180 * M_PI),
                                SPHSDK::Config::InitialGravitationalAcceleration.y * sin(angle / 180 * M_PI) +
@@ -206,7 +206,7 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
             break;
         case GLFW_KEY_HOME:
             angle = 360.0;
-            SPHSDK::Config::GravitationalAcceleration = SPHAlgorithms::Point3D(0.0, 0.0, -9.82);
+            SPHSDK::Config::GravitationalAcceleration = SPHAlgorithms::Point3F(0.0, 0.0, -9.82);
             break;
         case GLFW_KEY_ESCAPE:
             glfwSetWindowShouldClose(window, GLFW_TRUE);

--- a/demo/src/Draw.cpp
+++ b/demo/src/Draw.cpp
@@ -39,15 +39,6 @@ static SPHSDK::SPH sph;
 
 static SPHSDK::Point3FVector mesh;
 
-struct SVertex
-{
-    GLfloat x,y,z;
-    GLfloat r,g,b;
-};
-
-// TODO: optimize this, do not copy arrays to draw
-std::vector<SVertex> points(SPHSDK::Config::ParticlesNumber);
-
 void MyDisplay(void)
 {
     mat4x4 view;
@@ -78,7 +69,7 @@ void MyDisplay(void)
 
     sph.run();
 
-    const SPHSDK::FLOAT cubeSize = static_cast<SPHSDK::FLOAT>(SPHSDK::Config::CubeSize);
+    const auto cubeSize = SPHSDK::Config::CubeSize;
 
     // Draw the obstacle
     glBegin(GL_TRIANGLES);
@@ -93,8 +84,8 @@ void MyDisplay(void)
     glEnableClientState(GL_COLOR_ARRAY);
     glPointSize(pointSize);
 
-    glVertexPointer(3, GL_FLOAT, sizeof(SPHSDK::Particle), &sph.particles[0].position);
-    glColorPointer(3, GL_FLOAT, sizeof(SVertex), &sph.particles[0].colour);
+    glVertexPointer(3, GL_DOUBLE, sizeof(SPHSDK::Particle), &sph.particles[0].position);
+    glColorPointer(3, GL_DOUBLE, sizeof(SPHSDK::Particle), &sph.particles[0].colour);
     glDrawArrays(GL_POINTS, 0, SPHSDK::Config::ParticlesNumber);
 
     glDisableClientState(GL_COLOR_ARRAY);

--- a/sph/src/Collisions.cpp
+++ b/sph/src/Collisions.cpp
@@ -8,39 +8,39 @@ namespace SPHSDK
 {
 
 // (Formula 4.35)
-static double calculateF(const SPHAlgorithms::Point3F& differenceParticleNeighbour)
+static FLOAT calculateF(const Point3F& differenceParticleNeighbour)
 {
     return differenceParticleNeighbour.calcNormSqr() - Config::ParticleRadius * Config::ParticleRadius;
 }
 
 // (Formula 4.36)
-static SPHAlgorithms::Point3F calculateContactPoint(const SPHAlgorithms::Point3F& particlePosition,
-                                                    const SPHAlgorithms::Point3F& differenceParticleNeighbour)
+static Point3F calculateContactPoint(const Point3F& particlePosition,
+                                     const Point3F& differenceParticleNeighbour)
 {
-    const double particleDistance = differenceParticleNeighbour.calcNorm();
+    const FLOAT particleDistance = differenceParticleNeighbour.calcNorm();
     return particlePosition + (differenceParticleNeighbour / particleDistance) * Config::ParticleRadius;
 }
 
 // (Formula 4.38)
-static SPHAlgorithms::Point3F calculateSurfaceNormal(const SPHAlgorithms::Point3F& differenceParticleNeighbour)
+static Point3F calculateSurfaceNormal(const Point3F& differenceParticleNeighbour)
 {
-    const double particleDistance = differenceParticleNeighbour.calcNorm();
+    const FLOAT particleDistance = differenceParticleNeighbour.calcNorm();
     return -differenceParticleNeighbour / particleDistance;
 }
 
 // (Formula 4.56)
-static SPHAlgorithms::Point3F calculateVelocity(const SPHAlgorithms::Point3F& particleVelocity,
-                                                const SPHAlgorithms::Point3F& differenceParticleNeighbour)
+static Point3F calculateVelocity(const Point3F& particleVelocity,
+                                             const Point3F& differenceParticleNeighbour)
 {
-    const double scalarProduct = particleVelocity.x * differenceParticleNeighbour.x +
-                                 particleVelocity.y * differenceParticleNeighbour.y +
-                                 particleVelocity.z * differenceParticleNeighbour.z;
+    const FLOAT scalarProduct = particleVelocity.x * differenceParticleNeighbour.x +
+                                            particleVelocity.y * differenceParticleNeighbour.y +
+                                            particleVelocity.z * differenceParticleNeighbour.z;
     return particleVelocity - differenceParticleNeighbour * 2 * scalarProduct;
 }
 
 void Collision::detectCollisions(ParticleVect&                                    particleVect,
-                                 const SPHAlgorithms::Volume&                     volume,
-                                 const std::function<float(float, float, float)>* obstacle)
+                                 const Volume&                     volume,
+                                 const std::function<FLOAT(FLOAT, FLOAT, FLOAT)>* obstacle)
 {
     for (size_t i = 0; i < particleVect.size(); i++)
     {
@@ -48,13 +48,13 @@ void Collision::detectCollisions(ParticleVect&                                  
 
         for (size_t j = 0; j < particleVect[i].neighbours.size(); j++)
         {
-            SPHAlgorithms::Point3F differenceParticleNeighbour =
+            Point3F differenceParticleNeighbour =
                 particleVect[i].position - particleVect[particleVect[i].neighbours[j]].position;
 
             // (Formula 4.35)
             if (calculateF(differenceParticleNeighbour) < 0)
             {
-                const SPHAlgorithms::Point3F surfaceNormal = calculateSurfaceNormal(differenceParticleNeighbour);
+                const Point3 surfaceNormal = calculateSurfaceNormal(differenceParticleNeighbour);
 
                 // (Formula 4.55)
                 particleVect[i].position = calculateContactPoint(particleVect[i].position, differenceParticleNeighbour);
@@ -66,7 +66,7 @@ void Collision::detectCollisions(ParticleVect&                                  
 
         /* Boundary Collision */
 
-        const SPHAlgorithms::Cuboid cuboid = volume.getBoundingCuboid();
+        const Cuboid cuboid = volume.getBoundingCuboid();
 
         if (particleVect[i].position.x > cuboid.width - particleVect[i].radius)
         {
@@ -107,8 +107,8 @@ void Collision::detectCollisions(ParticleVect&                                  
         /* Obstacle collision */
 
         if (obstacle != nullptr &&
-            (*obstacle)(static_cast<float>(particleVect[i].position.x), static_cast<float>(particleVect[i].position.y),
-                        static_cast<float>(particleVect[i].position.z)) > 0.f)
+            (*obstacle)(static_cast<FLOAT>(particleVect[i].position.x), static_cast<FLOAT>(particleVect[i].position.y),
+                        static_cast<FLOAT>(particleVect[i].position.z)) > 0.f)
         {
             particleVect[i].position = particleVect[i].previous_position;
             particleVect[i].velocity *= Config::CollisionVelocityMultiplier;

--- a/sph/src/Collisions.cpp
+++ b/sph/src/Collisions.cpp
@@ -30,16 +30,16 @@ static Point3F calculateSurfaceNormal(const Point3F& differenceParticleNeighbour
 
 // (Formula 4.56)
 static Point3F calculateVelocity(const Point3F& particleVelocity,
-                                             const Point3F& differenceParticleNeighbour)
+                                 const Point3F& differenceParticleNeighbour)
 {
     const FLOAT scalarProduct = particleVelocity.x * differenceParticleNeighbour.x +
-                                            particleVelocity.y * differenceParticleNeighbour.y +
-                                            particleVelocity.z * differenceParticleNeighbour.z;
+                                particleVelocity.y * differenceParticleNeighbour.y +
+                                particleVelocity.z * differenceParticleNeighbour.z;
     return particleVelocity - differenceParticleNeighbour * 2 * scalarProduct;
 }
 
 void Collision::detectCollisions(ParticleVect&                                    particleVect,
-                                 const Volume&                     volume,
+                                 const Volume&                                    volume,
                                  const std::function<FLOAT(FLOAT, FLOAT, FLOAT)>* obstacle)
 {
     for (size_t i = 0; i < particleVect.size(); i++)

--- a/sph/src/Collisions.cpp
+++ b/sph/src/Collisions.cpp
@@ -8,29 +8,29 @@ namespace SPHSDK
 {
 
 // (Formula 4.35)
-static double calculateF(const SPHAlgorithms::Point3D& differenceParticleNeighbour)
+static double calculateF(const SPHAlgorithms::Point3F& differenceParticleNeighbour)
 {
     return differenceParticleNeighbour.calcNormSqr() - Config::ParticleRadius * Config::ParticleRadius;
 }
 
 // (Formula 4.36)
-static SPHAlgorithms::Point3D calculateContactPoint(const SPHAlgorithms::Point3D& particlePosition,
-                                                    const SPHAlgorithms::Point3D& differenceParticleNeighbour)
+static SPHAlgorithms::Point3F calculateContactPoint(const SPHAlgorithms::Point3F& particlePosition,
+                                                    const SPHAlgorithms::Point3F& differenceParticleNeighbour)
 {
     const double particleDistance = differenceParticleNeighbour.calcNorm();
     return particlePosition + (differenceParticleNeighbour / particleDistance) * Config::ParticleRadius;
 }
 
 // (Formula 4.38)
-static SPHAlgorithms::Point3D calculateSurfaceNormal(const SPHAlgorithms::Point3D& differenceParticleNeighbour)
+static SPHAlgorithms::Point3F calculateSurfaceNormal(const SPHAlgorithms::Point3F& differenceParticleNeighbour)
 {
     const double particleDistance = differenceParticleNeighbour.calcNorm();
     return -differenceParticleNeighbour / particleDistance;
 }
 
 // (Formula 4.56)
-static SPHAlgorithms::Point3D calculateVelocity(const SPHAlgorithms::Point3D& particleVelocity,
-                                                const SPHAlgorithms::Point3D& differenceParticleNeighbour)
+static SPHAlgorithms::Point3F calculateVelocity(const SPHAlgorithms::Point3F& particleVelocity,
+                                                const SPHAlgorithms::Point3F& differenceParticleNeighbour)
 {
     const double scalarProduct = particleVelocity.x * differenceParticleNeighbour.x +
                                  particleVelocity.y * differenceParticleNeighbour.y +
@@ -48,13 +48,13 @@ void Collision::detectCollisions(ParticleVect&                                  
 
         for (size_t j = 0; j < particleVect[i].neighbours.size(); j++)
         {
-            SPHAlgorithms::Point3D differenceParticleNeighbour =
+            SPHAlgorithms::Point3F differenceParticleNeighbour =
                 particleVect[i].position - particleVect[particleVect[i].neighbours[j]].position;
 
             // (Formula 4.35)
             if (calculateF(differenceParticleNeighbour) < 0)
             {
-                const SPHAlgorithms::Point3D surfaceNormal = calculateSurfaceNormal(differenceParticleNeighbour);
+                const SPHAlgorithms::Point3F surfaceNormal = calculateSurfaceNormal(differenceParticleNeighbour);
 
                 // (Formula 4.55)
                 particleVect[i].position = calculateContactPoint(particleVect[i].position, differenceParticleNeighbour);

--- a/sph/src/Collisions.h
+++ b/sph/src/Collisions.h
@@ -12,22 +12,19 @@
 
 #include <functional>
 
-namespace SPHAlgorithms
+namespace SPHSDK
 {
 class Area;
 class Volume;
-} // namespace SPHAlgorithms
 
-namespace SPHSDK
-{
 
 class Collision
 {
 
 public:
-    static void detectCollisions(ParticleVect&                                    particleVect,
-                                 const SPHAlgorithms::Volume&                     volume,
-                                 const std::function<float(float, float, float)>* obstacle = nullptr);
+    static void detectCollisions(ParticleVect& particleVect,
+                                 const Volume& volume,
+                                 const std::function<FLOAT(FLOAT, FLOAT, FLOAT)>* obstacle = nullptr);
 };
 
 } // namespace SPHSDK

--- a/sph/src/Config.cpp
+++ b/sph/src/Config.cpp
@@ -19,9 +19,9 @@ namespace SPHSDK
     const double Config::WaterSupportRadius = 0.1;
     const double Config::WaterSurfaceTension = 0.0728;
 
-    const SPHAlgorithms::Point3D Config::InitialGravitationalAcceleration(0.0, 0.0, -9.82);
-    SPHAlgorithms::Point3D Config::GravitationalAcceleration(0.0, 0.0, -9.82);
-    const SPHAlgorithms::Point3D Config::InitialVelocity(0.0, 0.0, 0.0);
+    const SPHAlgorithms::Point3F Config::InitialGravitationalAcceleration(0.0, 0.0, -9.82);
+    SPHAlgorithms::Point3F Config::GravitationalAcceleration(0.0, 0.0, -9.82);
+    const SPHAlgorithms::Point3F Config::InitialVelocity(0.0, 0.0, 0.0);
     const double Config::CollisionVelocityMultiplier = -0.5;
 
     const double Config::SpeedTreshold = 3.0;

--- a/sph/src/Config.cpp
+++ b/sph/src/Config.cpp
@@ -8,7 +8,7 @@
 
 namespace SPHSDK
 {
-    const size_t Config::ParticlesNumber = 6000;
+    const size_t Config::ParticlesNumber = 10000;
     const FLOAT Config::ParticleRadius = 0.015;
 
     const FLOAT Config::WaterDensity = 998.29;

--- a/sph/src/Config.cpp
+++ b/sph/src/Config.cpp
@@ -9,22 +9,22 @@
 namespace SPHSDK
 {
     const size_t Config::ParticlesNumber = 6000;
-    const double Config::ParticleRadius = 0.015;
+    const FLOAT Config::ParticleRadius = 0.015;
 
-    const double Config::WaterDensity = 998.29;
-    const double Config::WaterStiffness = 3.0;
-    const double Config::WaterViscosity = 3.5;
-    const double Config::WaterThreshold = 7.065;
-    const double Config::WaterParticleMass = 0.02;
-    const double Config::WaterSupportRadius = 0.1;
-    const double Config::WaterSurfaceTension = 0.0728;
+    const FLOAT Config::WaterDensity = 998.29;
+    const FLOAT Config::WaterStiffness = 3.0;
+    const FLOAT Config::WaterViscosity = 3.5;
+    const FLOAT Config::WaterThreshold = 7.065;
+    const FLOAT Config::WaterParticleMass = 0.02;
+    const FLOAT Config::WaterSupportRadius = 0.1;
+    const FLOAT Config::WaterSurfaceTension = 0.0728;
 
-    const SPHAlgorithms::Point3F Config::InitialGravitationalAcceleration(0.0, 0.0, -9.82);
-    SPHAlgorithms::Point3F Config::GravitationalAcceleration(0.0, 0.0, -9.82);
-    const SPHAlgorithms::Point3F Config::InitialVelocity(0.0, 0.0, 0.0);
-    const double Config::CollisionVelocityMultiplier = -0.5;
+    const Point3F Config::InitialGravitationalAcceleration(0.0, 0.0, -9.82);
+    Point3F Config::GravitationalAcceleration(0.0, 0.0, -9.82);
+    const Point3F Config::InitialVelocity(0.0, 0.0, 0.0);
+    const FLOAT Config::CollisionVelocityMultiplier = -0.5;
 
-    const double Config::SpeedTreshold = 3.0;
+    const FLOAT Config::SpeedTreshold = 3.0;
 
-    const double Config::CubeSize = 3.0;
+    const FLOAT Config::CubeSize = 3.0;
 } //SPHSDK

--- a/sph/src/Config.cpp
+++ b/sph/src/Config.cpp
@@ -8,7 +8,7 @@
 
 namespace SPHSDK
 {
-    const size_t Config::ParticlesNumber = 10000;
+    const size_t Config::ParticlesNumber = 6000;
     const FLOAT Config::ParticleRadius = 0.015;
 
     const FLOAT Config::WaterDensity = 998.29;

--- a/sph/src/Config.h
+++ b/sph/src/Config.h
@@ -20,9 +20,9 @@ struct Config
     static const double WaterSupportRadius;
     static const double WaterSurfaceTension;
 
-    static const SPHAlgorithms::Point3D InitialGravitationalAcceleration;
-    static SPHAlgorithms::Point3D GravitationalAcceleration;
-    static const SPHAlgorithms::Point3D InitialVelocity;
+    static const SPHAlgorithms::Point3F InitialGravitationalAcceleration;
+    static SPHAlgorithms::Point3F GravitationalAcceleration;
+    static const SPHAlgorithms::Point3F InitialVelocity;
     static const double CollisionVelocityMultiplier;
 
     static const double SpeedTreshold;

--- a/sph/src/Config.h
+++ b/sph/src/Config.h
@@ -10,24 +10,24 @@ namespace SPHSDK
 struct Config
 {
     static const size_t ParticlesNumber;
-    static const double ParticleRadius;
+    static const FLOAT ParticleRadius;
 
-    static const double WaterDensity;
-    static const double WaterStiffness;
-    static const double WaterViscosity;
-    static const double WaterThreshold;
-    static const double WaterParticleMass;
-    static const double WaterSupportRadius;
-    static const double WaterSurfaceTension;
+    static const FLOAT WaterDensity;
+    static const FLOAT WaterStiffness;
+    static const FLOAT WaterViscosity;
+    static const FLOAT WaterThreshold;
+    static const FLOAT WaterParticleMass;
+    static const FLOAT WaterSupportRadius;
+    static const FLOAT WaterSurfaceTension;
 
-    static const SPHAlgorithms::Point3F InitialGravitationalAcceleration;
-    static SPHAlgorithms::Point3F GravitationalAcceleration;
-    static const SPHAlgorithms::Point3F InitialVelocity;
-    static const double CollisionVelocityMultiplier;
+    static const Point3F InitialGravitationalAcceleration;
+    static Point3F GravitationalAcceleration;
+    static const Point3F InitialVelocity;
+    static const FLOAT CollisionVelocityMultiplier;
 
-    static const double SpeedTreshold;
+    static const FLOAT SpeedTreshold;
 
-    static const double CubeSize;
+    static const FLOAT CubeSize;
 
 }; //Config
 } //SPHSDK

--- a/sph/src/Forces.cpp
+++ b/sph/src/Forces.cpp
@@ -18,13 +18,13 @@ static const double KernelViscosityLaplacianMultiplier = 45.0 / PiPowH6;
 static const double OwnDensity = 315.0 / (64.0 * M_PI * pow(Config::WaterSupportRadius, 3));
 
 
-static double defaultKernel(const SPHAlgorithms::Point3D& differenceParticleNeighbour) {
+static double defaultKernel(const SPHAlgorithms::Point3F& differenceParticleNeighbour) {
     // (Formula 4.3)
     const double particleDistanceSqr = differenceParticleNeighbour.calcNormSqr();
     return KernelDefaultMultiplier * pow(SupportRadiusSqr - particleDistanceSqr, 3);
 }
 
-static SPHAlgorithms::Point3D defaultKernelGradient(const SPHAlgorithms::Point3D& differenceParticleNeighbour) {
+static SPHAlgorithms::Point3F defaultKernelGradient(const SPHAlgorithms::Point3F& differenceParticleNeighbour) {
     // (Formula 4.4)
     const double particleDistanceSqr = differenceParticleNeighbour.calcNormSqr();
     return differenceParticleNeighbour * KernelDefaultGradientMultiplier
@@ -32,14 +32,14 @@ static SPHAlgorithms::Point3D defaultKernelGradient(const SPHAlgorithms::Point3D
                                        * (SupportRadiusSqr - particleDistanceSqr);
 }
 
-static double defaultKernelLaplacian(const SPHAlgorithms::Point3D& differenceParticleNeighbour) {
+static double defaultKernelLaplacian(const SPHAlgorithms::Point3F& differenceParticleNeighbour) {
     // (Formula 4.5)
     const double particleDistanceSqr = differenceParticleNeighbour.calcNormSqr();
     return KernelDefaultGradientMultiplier * (SupportRadiusSqr - particleDistanceSqr)
                                            * (3.0 * SupportRadiusSqr - 7.0 * particleDistanceSqr);
 }
 
-static SPHAlgorithms::Point3D pressureKernelGradient(const SPHAlgorithms::Point3D& differenceParticleNeighbour) {
+static SPHAlgorithms::Point3F pressureKernelGradient(const SPHAlgorithms::Point3F& differenceParticleNeighbour) {
     // (Formula 4.14)
     const double particleDistance = differenceParticleNeighbour.calcNorm();
     return differenceParticleNeighbour * KernelPressureGradientMultiplier / particleDistance
@@ -47,7 +47,7 @@ static SPHAlgorithms::Point3D pressureKernelGradient(const SPHAlgorithms::Point3
                                        * (Config::WaterSupportRadius - particleDistance);
 }
 
-static double viscosityKernelLaplacian(const SPHAlgorithms::Point3D& differenceParticleNeighbour) {
+static double viscosityKernelLaplacian(const SPHAlgorithms::Point3F& differenceParticleNeighbour) {
     // (Formula 4.22)
     const double particleDistance = differenceParticleNeighbour.calcNorm();
     return KernelViscosityLaplacianMultiplier * (Config::WaterSupportRadius - particleDistance);
@@ -62,7 +62,7 @@ void Forces::ComputeDensity(ParticleVect& particleVect)
 
         for (size_t j = 0; j < particleVect[i].neighbours.size(); j++)
         {
-            const SPHAlgorithms::Point3D differenceParticleNeighbour =
+            const SPHAlgorithms::Point3F differenceParticleNeighbour =
                 particleVect[i].position - particleVect[particleVect[i].neighbours[j]].position;
 
             if (Config::WaterSupportRadius - differenceParticleNeighbour.calcNorm() > DBL_EPSILON)
@@ -84,15 +84,15 @@ void Forces::ComputeInternalForces(ParticleVect& particleVect)
 {
     for (size_t i = 0; i < particleVect.size(); i++)
     {
-        particleVect[i].fPressure = SPHAlgorithms::Point3D();
-        particleVect[i].fViscosity = SPHAlgorithms::Point3D();
+        particleVect[i].fPressure = SPHAlgorithms::Point3F();
+        particleVect[i].fViscosity = SPHAlgorithms::Point3F();
 
         for (size_t j = 0; j < particleVect[i].neighbours.size(); j++)
         {
             assert(std::abs(particleVect[i].density) > 0.);
             assert(std::abs(particleVect[particleVect[i].neighbours[j]].density) > 0.);
 
-            const SPHAlgorithms::Point3D differenceParticleNeighbour =
+            const SPHAlgorithms::Point3F differenceParticleNeighbour =
                 particleVect[i].position - particleVect[particleVect[i].neighbours[j]].position;
 
             const double particleDistance = differenceParticleNeighbour.calcNorm();
@@ -134,9 +134,9 @@ void Forces::ComputeSurfaceTension(ParticleVect& particleVect)
 {
     for (size_t i = 0; i < particleVect.size(); i++)
     {
-        particleVect[i].fSurfaceTension = SPHAlgorithms::Point3D();
+        particleVect[i].fSurfaceTension = SPHAlgorithms::Point3F();
 
-        SPHAlgorithms::Point3D surfaceTensionGradient = SPHAlgorithms::Point3D();
+        SPHAlgorithms::Point3F surfaceTensionGradient = SPHAlgorithms::Point3F();
         double surfaceTensionLaplacian = 0.0;
 
         for (size_t j = 0; j < particleVect[i].neighbours.size(); j++)
@@ -144,7 +144,7 @@ void Forces::ComputeSurfaceTension(ParticleVect& particleVect)
             assert(std::abs(particleVect[i].density) > 0.);
             assert(std::abs(particleVect[particleVect[i].neighbours[j]].density) > 0.);
 
-            const SPHAlgorithms::Point3D differenceParticleNeighbour =
+            const SPHAlgorithms::Point3F differenceParticleNeighbour =
                 particleVect[i].position - particleVect[particleVect[i].neighbours[j]].position;
 
             if (differenceParticleNeighbour.calcNormSqr() <= SupportRadiusSqr)

--- a/sph/src/Forces.cpp
+++ b/sph/src/Forces.cpp
@@ -8,48 +8,48 @@
 namespace SPHSDK
 {
 
-static const double PiPowH9 = M_PI * pow(Config::WaterSupportRadius, 9);
-static const double PiPowH6 = M_PI * pow(Config::WaterSupportRadius, 6);
-static const double SupportRadiusSqr = Config::WaterSupportRadius * Config::WaterSupportRadius;
-static const double KernelDefaultMultiplier = 315.0 / (64.0 * PiPowH9);
-static const double KernelDefaultGradientMultiplier = -945.0 / (32.0 * PiPowH9);
-static const double KernelPressureGradientMultiplier = -45.0 / PiPowH6;
-static const double KernelViscosityLaplacianMultiplier = 45.0 / PiPowH6;
-static const double OwnDensity = 315.0 / (64.0 * M_PI * pow(Config::WaterSupportRadius, 3));
+static const FLOAT PiPowH9 = M_PI * pow(Config::WaterSupportRadius, 9);
+static const FLOAT PiPowH6 = M_PI * pow(Config::WaterSupportRadius, 6);
+static const FLOAT SupportRadiusSqr = Config::WaterSupportRadius * Config::WaterSupportRadius;
+static const FLOAT KernelDefaultMultiplier = 315.0 / (64.0 * PiPowH9);
+static const FLOAT KernelDefaultGradientMultiplier = -945.0 / (32.0 * PiPowH9);
+static const FLOAT KernelPressureGradientMultiplier = -45.0 / PiPowH6;
+static const FLOAT KernelViscosityLaplacianMultiplier = 45.0 / PiPowH6;
+static const FLOAT OwnDensity = 315.0 / (64.0 * M_PI * pow(Config::WaterSupportRadius, 3));
 
 
-static double defaultKernel(const SPHAlgorithms::Point3F& differenceParticleNeighbour) {
+static FLOAT defaultKernel(const Point3F& differenceParticleNeighbour) {
     // (Formula 4.3)
-    const double particleDistanceSqr = differenceParticleNeighbour.calcNormSqr();
+    const FLOAT particleDistanceSqr = differenceParticleNeighbour.calcNormSqr();
     return KernelDefaultMultiplier * pow(SupportRadiusSqr - particleDistanceSqr, 3);
 }
 
-static SPHAlgorithms::Point3F defaultKernelGradient(const SPHAlgorithms::Point3F& differenceParticleNeighbour) {
+static Point3F defaultKernelGradient(const Point3F& differenceParticleNeighbour) {
     // (Formula 4.4)
-    const double particleDistanceSqr = differenceParticleNeighbour.calcNormSqr();
+    const FLOAT particleDistanceSqr = differenceParticleNeighbour.calcNormSqr();
     return differenceParticleNeighbour * KernelDefaultGradientMultiplier
                                        * (SupportRadiusSqr - particleDistanceSqr)
                                        * (SupportRadiusSqr - particleDistanceSqr);
 }
 
-static double defaultKernelLaplacian(const SPHAlgorithms::Point3F& differenceParticleNeighbour) {
+static FLOAT defaultKernelLaplacian(const Point3F& differenceParticleNeighbour) {
     // (Formula 4.5)
-    const double particleDistanceSqr = differenceParticleNeighbour.calcNormSqr();
+    const FLOAT particleDistanceSqr = differenceParticleNeighbour.calcNormSqr();
     return KernelDefaultGradientMultiplier * (SupportRadiusSqr - particleDistanceSqr)
                                            * (3.0 * SupportRadiusSqr - 7.0 * particleDistanceSqr);
 }
 
-static SPHAlgorithms::Point3F pressureKernelGradient(const SPHAlgorithms::Point3F& differenceParticleNeighbour) {
+static Point3F pressureKernelGradient(const Point3F& differenceParticleNeighbour) {
     // (Formula 4.14)
-    const double particleDistance = differenceParticleNeighbour.calcNorm();
+    const FLOAT particleDistance = differenceParticleNeighbour.calcNorm();
     return differenceParticleNeighbour * KernelPressureGradientMultiplier / particleDistance
                                        * (Config::WaterSupportRadius - particleDistance)
                                        * (Config::WaterSupportRadius - particleDistance);
 }
 
-static double viscosityKernelLaplacian(const SPHAlgorithms::Point3F& differenceParticleNeighbour) {
+static FLOAT viscosityKernelLaplacian(const Point3F& differenceParticleNeighbour) {
     // (Formula 4.22)
-    const double particleDistance = differenceParticleNeighbour.calcNorm();
+    const FLOAT particleDistance = differenceParticleNeighbour.calcNorm();
     return KernelViscosityLaplacianMultiplier * (Config::WaterSupportRadius - particleDistance);
 }
 
@@ -62,7 +62,7 @@ void Forces::ComputeDensity(ParticleVect& particleVect)
 
         for (size_t j = 0; j < particleVect[i].neighbours.size(); j++)
         {
-            const SPHAlgorithms::Point3F differenceParticleNeighbour =
+            const Point3F differenceParticleNeighbour =
                 particleVect[i].position - particleVect[particleVect[i].neighbours[j]].position;
 
             if (Config::WaterSupportRadius - differenceParticleNeighbour.calcNorm() > DBL_EPSILON)
@@ -84,22 +84,22 @@ void Forces::ComputeInternalForces(ParticleVect& particleVect)
 {
     for (size_t i = 0; i < particleVect.size(); i++)
     {
-        particleVect[i].fPressure = SPHAlgorithms::Point3F();
-        particleVect[i].fViscosity = SPHAlgorithms::Point3F();
+        particleVect[i].fPressure = Point3F();
+        particleVect[i].fViscosity = Point3F();
 
         for (size_t j = 0; j < particleVect[i].neighbours.size(); j++)
         {
             assert(std::abs(particleVect[i].density) > 0.);
             assert(std::abs(particleVect[particleVect[i].neighbours[j]].density) > 0.);
 
-            const SPHAlgorithms::Point3F differenceParticleNeighbour =
+            const Point3F differenceParticleNeighbour =
                 particleVect[i].position - particleVect[particleVect[i].neighbours[j]].position;
 
-            const double particleDistance = differenceParticleNeighbour.calcNorm();
+            const FLOAT particleDistance = differenceParticleNeighbour.calcNorm();
 
             if (std::abs(particleDistance) > 0.)
             {
-                const double dividedMassDensity =
+                const FLOAT dividedMassDensity =
                     Config::WaterParticleMass / particleVect[particleVect[i].neighbours[j]].density;
 
                 // (Formulae 4.11 & 4.14)
@@ -134,22 +134,22 @@ void Forces::ComputeSurfaceTension(ParticleVect& particleVect)
 {
     for (size_t i = 0; i < particleVect.size(); i++)
     {
-        particleVect[i].fSurfaceTension = SPHAlgorithms::Point3F();
+        particleVect[i].fSurfaceTension = Point3F();
 
-        SPHAlgorithms::Point3F surfaceTensionGradient = SPHAlgorithms::Point3F();
-        double surfaceTensionLaplacian = 0.0;
+        Point3F surfaceTensionGradient = Point3F();
+        FLOAT surfaceTensionLaplacian = 0.0;
 
         for (size_t j = 0; j < particleVect[i].neighbours.size(); j++)
         {
             assert(std::abs(particleVect[i].density) > 0.);
             assert(std::abs(particleVect[particleVect[i].neighbours[j]].density) > 0.);
 
-            const SPHAlgorithms::Point3F differenceParticleNeighbour =
+            const Point3F differenceParticleNeighbour =
                 particleVect[i].position - particleVect[particleVect[i].neighbours[j]].position;
 
             if (differenceParticleNeighbour.calcNormSqr() <= SupportRadiusSqr)
             {
-                const double dividedMassDensity =
+                const FLOAT dividedMassDensity =
                     Config::WaterParticleMass / particleVect[particleVect[i].neighbours[j]].density;
 
                 // (Formulae 4.28 & 4.4)

--- a/sph/src/Integrator.cpp
+++ b/sph/src/Integrator.cpp
@@ -12,18 +12,18 @@
 namespace SPHSDK
 {
 
-void Integrator::integrate(double timeStep, ParticleVect& particles)
+void Integrator::integrate(FLOAT timeStep, ParticleVect& particles)
 {
     for (auto& particle : particles)
     {
         particle.previous_position = particle.position;
 
-        const SPHAlgorithms::Point3F prevAcceleration = particle.acceleration;
+        const Point3F prevAcceleration = particle.acceleration;
 
         if (std::abs(particle.density) > 0.)
             particle.acceleration = particle.fTotal / particle.density;
 
-        const SPHAlgorithms::Point3F prevVelocity = particle.velocity;
+        const Point3F prevVelocity = particle.velocity;
 
         particle.velocity += (prevAcceleration + particle.acceleration) / 2.0 * timeStep;
 

--- a/sph/src/Integrator.cpp
+++ b/sph/src/Integrator.cpp
@@ -31,6 +31,19 @@ void Integrator::integrate(FLOAT timeStep, ParticleVect& particles)
             particle.velocity = prevVelocity;
 
         particle.position += prevVelocity * timeStep + prevAcceleration / 2.0 * timeStep * timeStep;
+
+        // color depends on velocity
+        const SPHSDK::FLOAT velocityNorm = particle.velocity.calcNormSqr();
+        particle.colour = Point3F(0.0f, 0.0f, 1.0f);
+
+        if (velocityNorm > SPHSDK::Config::SpeedTreshold / 2.)
+        {
+            particle.colour = Point3F(1.0f, 0.0f, 0.0f);
+        }
+        else if (velocityNorm > SPHSDK::Config::SpeedTreshold / 4.)
+        {
+            particle.colour = Point3F(0.99f, 0.7f, 0.0f);
+        }
     }
 }
 

--- a/sph/src/Integrator.cpp
+++ b/sph/src/Integrator.cpp
@@ -18,12 +18,12 @@ void Integrator::integrate(double timeStep, ParticleVect& particles)
     {
         particle.previous_position = particle.position;
 
-        const SPHAlgorithms::Point3D prevAcceleration = particle.acceleration;
+        const SPHAlgorithms::Point3F prevAcceleration = particle.acceleration;
 
         if (std::abs(particle.density) > 0.)
             particle.acceleration = particle.fTotal / particle.density;
 
-        const SPHAlgorithms::Point3D prevVelocity = particle.velocity;
+        const SPHAlgorithms::Point3F prevVelocity = particle.velocity;
 
         particle.velocity += (prevAcceleration + particle.acceleration) / 2.0 * timeStep;
 

--- a/sph/src/Integrator.h
+++ b/sph/src/Integrator.h
@@ -15,7 +15,7 @@ namespace SPHSDK
 class Integrator
 {
 public:
-    static void integrate(double timeStep, ParticleVect& particles);
+    static void integrate(FLOAT timeStep, ParticleVect& particles);
 };
 
 } //SPHSDK

--- a/sph/src/Particle.cpp
+++ b/sph/src/Particle.cpp
@@ -11,6 +11,7 @@ namespace SPHSDK
 
 Particle::Particle() :
     position(Point3F()),
+    colour(Point3F()),
     radius(0.0),
     density(0.0),
     pressure(0.0),
@@ -30,6 +31,7 @@ Particle::Particle() :
 
 Particle::Particle(const Point3F& position, FLOAT radius) :
     position(position),
+    colour(Point3F()),
     radius(radius),
     density(0.0),
     pressure(0.0),

--- a/sph/src/Particle.cpp
+++ b/sph/src/Particle.cpp
@@ -10,40 +10,40 @@ namespace SPHSDK
 {
 
 Particle::Particle() :
+    position(SPHAlgorithms::Point3F()),
     radius(0.0),
     density(0.0),
     pressure(0.0),
     mass(0.0),
     supportRadius(0.0),
-    position(SPHAlgorithms::Point3D()),
-    velocity(SPHAlgorithms::Point3D()),
-    acceleration(SPHAlgorithms::Point3D()),
-    fGravity(SPHAlgorithms::Point3D()),
-    fSurfaceTension(SPHAlgorithms::Point3D()),
-    fViscosity(SPHAlgorithms::Point3D()),
-    fPressure(SPHAlgorithms::Point3D()),
-    fExternal(SPHAlgorithms::Point3D()),
-    fInternal(SPHAlgorithms::Point3D()),
-    fTotal(SPHAlgorithms::Point3D())
+    velocity(SPHAlgorithms::Point3F()),
+    acceleration(SPHAlgorithms::Point3F()),
+    fGravity(SPHAlgorithms::Point3F()),
+    fSurfaceTension(SPHAlgorithms::Point3F()),
+    fViscosity(SPHAlgorithms::Point3F()),
+    fPressure(SPHAlgorithms::Point3F()),
+    fExternal(SPHAlgorithms::Point3F()),
+    fInternal(SPHAlgorithms::Point3F()),
+    fTotal(SPHAlgorithms::Point3F())
 {
 }
 
-Particle::Particle(const SPHAlgorithms::Point3D & position, double radius) :
+Particle::Particle(const SPHAlgorithms::Point3F& position, double radius) :
+    position(position),
     radius(radius),
     density(0.0),
     pressure(0.0),
     mass(0.0),
     supportRadius(0.0),
-    position(position),
-    velocity(SPHAlgorithms::Point3D()),
-    acceleration(SPHAlgorithms::Point3D()),
-    fGravity(SPHAlgorithms::Point3D()),
-    fSurfaceTension(SPHAlgorithms::Point3D()),
-    fViscosity(SPHAlgorithms::Point3D()),
-    fPressure(SPHAlgorithms::Point3D()),
-    fExternal(SPHAlgorithms::Point3D()),
-    fInternal(SPHAlgorithms::Point3D()),
-    fTotal(SPHAlgorithms::Point3D())
+    velocity(SPHAlgorithms::Point3F()),
+    acceleration(SPHAlgorithms::Point3F()),
+    fGravity(SPHAlgorithms::Point3F()),
+    fSurfaceTension(SPHAlgorithms::Point3F()),
+    fViscosity(SPHAlgorithms::Point3F()),
+    fPressure(SPHAlgorithms::Point3F()),
+    fExternal(SPHAlgorithms::Point3F()),
+    fInternal(SPHAlgorithms::Point3F()),
+    fTotal(SPHAlgorithms::Point3F())
 {
 }
 

--- a/sph/src/Particle.cpp
+++ b/sph/src/Particle.cpp
@@ -10,40 +10,40 @@ namespace SPHSDK
 {
 
 Particle::Particle() :
-    position(SPHAlgorithms::Point3F()),
+    position(Point3F()),
     radius(0.0),
     density(0.0),
     pressure(0.0),
     mass(0.0),
     supportRadius(0.0),
-    velocity(SPHAlgorithms::Point3F()),
-    acceleration(SPHAlgorithms::Point3F()),
-    fGravity(SPHAlgorithms::Point3F()),
-    fSurfaceTension(SPHAlgorithms::Point3F()),
-    fViscosity(SPHAlgorithms::Point3F()),
-    fPressure(SPHAlgorithms::Point3F()),
-    fExternal(SPHAlgorithms::Point3F()),
-    fInternal(SPHAlgorithms::Point3F()),
-    fTotal(SPHAlgorithms::Point3F())
+    velocity(Point3F()),
+    acceleration(Point3F()),
+    fGravity(Point3F()),
+    fSurfaceTension(Point3F()),
+    fViscosity(Point3F()),
+    fPressure(Point3F()),
+    fExternal(Point3F()),
+    fInternal(Point3F()),
+    fTotal(Point3F())
 {
 }
 
-Particle::Particle(const SPHAlgorithms::Point3F& position, double radius) :
+Particle::Particle(const Point3F& position, FLOAT radius) :
     position(position),
     radius(radius),
     density(0.0),
     pressure(0.0),
     mass(0.0),
     supportRadius(0.0),
-    velocity(SPHAlgorithms::Point3F()),
-    acceleration(SPHAlgorithms::Point3F()),
-    fGravity(SPHAlgorithms::Point3F()),
-    fSurfaceTension(SPHAlgorithms::Point3F()),
-    fViscosity(SPHAlgorithms::Point3F()),
-    fPressure(SPHAlgorithms::Point3F()),
-    fExternal(SPHAlgorithms::Point3F()),
-    fInternal(SPHAlgorithms::Point3F()),
-    fTotal(SPHAlgorithms::Point3F())
+    velocity(Point3F()),
+    acceleration(Point3F()),
+    fGravity(Point3F()),
+    fSurfaceTension(Point3F()),
+    fViscosity(Point3F()),
+    fPressure(Point3F()),
+    fExternal(Point3F()),
+    fInternal(Point3F()),
+    fTotal(Point3F())
 {
 }
 

--- a/sph/src/Particle.h
+++ b/sph/src/Particle.h
@@ -29,31 +29,31 @@ class Particle
 public:
     Particle();
 
-    Particle(const SPHAlgorithms::Point3F& position, double radius = Config::ParticleRadius);
+    Particle(const Point3F& position, FLOAT radius = Config::ParticleRadius);
 
-    SPHAlgorithms::Point3F position;
+    Point3F position;
 
-    double radius;
-    double density;
-    double pressure;
-    double mass;
-    double supportRadius;
+    FLOAT radius;
+    FLOAT density;
+    FLOAT pressure;
+    FLOAT mass;
+    FLOAT supportRadius;
 
-    SPHAlgorithms::Point3F previous_position;
-    SPHAlgorithms::Point3F velocity;
-    SPHAlgorithms::Point3F acceleration;
+    Point3F previous_position;
+    Point3F velocity;
+    Point3F acceleration;
 
-    SPHAlgorithms::Point3F fGravity;
-    SPHAlgorithms::Point3F fSurfaceTension;
-    SPHAlgorithms::Point3F fViscosity;
-    SPHAlgorithms::Point3F fPressure;
+    Point3F fGravity;
+    Point3F fSurfaceTension;
+    Point3F fViscosity;
+    Point3F fPressure;
 
-    SPHAlgorithms::Point3F fExternal;
-    SPHAlgorithms::Point3F fInternal;
+    Point3F fExternal;
+    Point3F fInternal;
 
-    SPHAlgorithms::Point3F fTotal;
+    Point3F fTotal;
 
-    SPHAlgorithms::SizetVector neighbours;
+    SizetVector neighbours;
 };
 
 using ParticleVect = std::vector<Particle>;

--- a/sph/src/Particle.h
+++ b/sph/src/Particle.h
@@ -32,6 +32,7 @@ public:
     Particle(const Point3F& position, FLOAT radius = Config::ParticleRadius);
 
     Point3F position;
+    Point3F colour;
 
     FLOAT radius;
     FLOAT density;

--- a/sph/src/Particle.h
+++ b/sph/src/Particle.h
@@ -29,7 +29,9 @@ class Particle
 public:
     Particle();
 
-    Particle(const SPHAlgorithms::Point3D& position, double radius = Config::ParticleRadius);
+    Particle(const SPHAlgorithms::Point3F& position, double radius = Config::ParticleRadius);
+
+    SPHAlgorithms::Point3F position;
 
     double radius;
     double density;
@@ -37,20 +39,19 @@ public:
     double mass;
     double supportRadius;
 
-    SPHAlgorithms::Point3D position;
-    SPHAlgorithms::Point3D previous_position;
-    SPHAlgorithms::Point3D velocity;
-    SPHAlgorithms::Point3D acceleration;
+    SPHAlgorithms::Point3F previous_position;
+    SPHAlgorithms::Point3F velocity;
+    SPHAlgorithms::Point3F acceleration;
 
-    SPHAlgorithms::Point3D fGravity;
-    SPHAlgorithms::Point3D fSurfaceTension;
-    SPHAlgorithms::Point3D fViscosity;
-    SPHAlgorithms::Point3D fPressure;
+    SPHAlgorithms::Point3F fGravity;
+    SPHAlgorithms::Point3F fSurfaceTension;
+    SPHAlgorithms::Point3F fViscosity;
+    SPHAlgorithms::Point3F fPressure;
 
-    SPHAlgorithms::Point3D fExternal;
-    SPHAlgorithms::Point3D fInternal;
+    SPHAlgorithms::Point3F fExternal;
+    SPHAlgorithms::Point3F fInternal;
 
-    SPHAlgorithms::Point3D fTotal;
+    SPHAlgorithms::Point3F fTotal;
 
     SPHAlgorithms::SizetVector neighbours;
 };

--- a/sph/src/SPH.cpp
+++ b/sph/src/SPH.cpp
@@ -41,8 +41,8 @@ SPH::SPH(const std::function<FLOAT(FLOAT, FLOAT, FLOAT)>* obstacle)
     FLOAT fi = 0.;
     FLOAT teta = 0.;
 
-    size_t M = 5;
-    size_t N = 5;
+    size_t M = 10;
+    size_t N = 10;
 
     size_t m = 0;
     size_t n = 0;

--- a/sph/src/SPH.cpp
+++ b/sph/src/SPH.cpp
@@ -15,30 +15,31 @@
 #include <cmath>
 #include <iostream>
 
-static const double PI = 3.14159265359;
 
 namespace SPHSDK
 {
 
+static const FLOAT PI = 3.14159265359;
+
 namespace
 {
-inline SPHAlgorithms::Point3F SpericalToCartesian(double r, double fi, double teta)
+inline Point3F SpericalToCartesian(FLOAT r, FLOAT fi, FLOAT teta)
 {
-    return SPHAlgorithms::Point3F(r * sin(teta) * cos(fi) + 1.5, r * sin(teta) * sin(fi) + 1.5, r * cos(teta) + 2.);
+    return Point3F(r * sin(teta) * cos(fi) + 1.5, r * sin(teta) * sin(fi) + 1.5, r * cos(teta) + 2.);
 }
 } // namespace
 
-SPH::SPH(const std::function<float(float, float, float)>* obstacle)
+SPH::SPH(const std::function<FLOAT(FLOAT, FLOAT, FLOAT)>* obstacle)
     : particles(Config::ParticlesNumber)
-    , m_volume(SPHAlgorithms::Volume(
-          SPHAlgorithms::Cuboid(SPHAlgorithms::Point3F(), Config::CubeSize, Config::CubeSize, Config::CubeSize)))
-    , m_searcher(SPHAlgorithms::NeighboursSearch3D<ParticleVect>(m_volume, Config::WaterSupportRadius, 0.001))
+    , m_volume(Volume(
+          Cuboid(Point3F(), Config::CubeSize, Config::CubeSize, Config::CubeSize)))
+    , m_searcher(NeighboursSearch3D<ParticleVect>(m_volume, Config::WaterSupportRadius, 0.001))
     , m_obstacle(obstacle)
 {
     // set initial particle data
-    double r = 2 * Config::ParticleRadius;
-    double fi = 0.;
-    double teta = 0.;
+    FLOAT r = 2 * Config::ParticleRadius;
+    FLOAT fi = 0.;
+    FLOAT teta = 0.;
 
     size_t M = 5;
     size_t N = 5;

--- a/sph/src/SPH.cpp
+++ b/sph/src/SPH.cpp
@@ -22,16 +22,16 @@ namespace SPHSDK
 
 namespace
 {
-inline SPHAlgorithms::Point3D SpericalToCartesian(double r, double fi, double teta)
+inline SPHAlgorithms::Point3F SpericalToCartesian(double r, double fi, double teta)
 {
-    return SPHAlgorithms::Point3D(r * sin(teta) * cos(fi) + 1.5, r * sin(teta) * sin(fi) + 1.5, r * cos(teta) + 2.);
+    return SPHAlgorithms::Point3F(r * sin(teta) * cos(fi) + 1.5, r * sin(teta) * sin(fi) + 1.5, r * cos(teta) + 2.);
 }
 } // namespace
 
 SPH::SPH(const std::function<float(float, float, float)>* obstacle)
     : particles(Config::ParticlesNumber)
     , m_volume(SPHAlgorithms::Volume(
-          SPHAlgorithms::Cuboid(SPHAlgorithms::Point3D(), Config::CubeSize, Config::CubeSize, Config::CubeSize)))
+          SPHAlgorithms::Cuboid(SPHAlgorithms::Point3F(), Config::CubeSize, Config::CubeSize, Config::CubeSize)))
     , m_searcher(SPHAlgorithms::NeighboursSearch3D<ParticleVect>(m_volume, Config::WaterSupportRadius, 0.001))
     , m_obstacle(obstacle)
 {

--- a/sph/src/SPH.h
+++ b/sph/src/SPH.h
@@ -21,7 +21,7 @@ namespace SPHSDK
 class SPH
 {
 public:
-    SPH(const std::function<float(float, float, float)>* obstacle = nullptr);
+    SPH(const std::function<FLOAT(FLOAT, FLOAT, FLOAT)>* obstacle = nullptr);
 
     void run();
 
@@ -29,11 +29,11 @@ public:
     ParticleVect particles;
 
 private:
-    SPHAlgorithms::Volume m_volume;
+    Volume m_volume;
 
-    SPHAlgorithms::NeighboursSearch3D<ParticleVect> m_searcher;
+    NeighboursSearch3D<ParticleVect> m_searcher;
 
-    const std::function<float(float, float, float)>* m_obstacle;
+    const std::function<FLOAT(FLOAT, FLOAT, FLOAT)>* m_obstacle;
 };
 
 } // namespace SPHSDK

--- a/sph/test/src/CollisionsTestSuite.cpp
+++ b/sph/test/src/CollisionsTestSuite.cpp
@@ -18,13 +18,13 @@ namespace TestEnvironment
 
 void CollisionsTestSuite::twoParticleCollision()
 {
-    ParticleVect particleVector = {Particle(SPHAlgorithms::Point3F(0.01, 0.01, 0.01), 0.1),
-                                   Particle(SPHAlgorithms::Point3F(0.09, 0.09, 0.09), 0.1)};
-    particleVector[0].velocity = SPHAlgorithms::Point3F(2.0, 2.0, 2.0);
-    particleVector[1].velocity = SPHAlgorithms::Point3F(-2.0, -2.0, -2.0);
+    ParticleVect particleVector = {Particle(Point3F(0.01, 0.01, 0.01), 0.1),
+                                   Particle(Point3F(0.09, 0.09, 0.09), 0.1)};
+    particleVector[0].velocity = Point3F(2.0, 2.0, 2.0);
+    particleVector[1].velocity = Point3F(-2.0, -2.0, -2.0);
     particleVector[0].neighbours = {1};
     particleVector[1].neighbours = {0};
-    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3F(0.0, 0.0, 0.0), 1.0, 1.0, 1.0));
+    Volume volume(Cuboid(Point3F(0.0, 0.0, 0.0), 1.0, 1.0, 1.0));
 
     Collision::detectCollisions(particleVector, volume);
 
@@ -45,17 +45,17 @@ void CollisionsTestSuite::twoParticleCollision()
 
 void CollisionsTestSuite::threeParticleCollision()
 {
-    ParticleVect particleVector = {Particle(SPHAlgorithms::Point3F(1.0, 1.0, 1.0), 1.6),
-                                   Particle(SPHAlgorithms::Point3F(3.0, 1.0, 1.0), 1.6),
-                                   Particle(SPHAlgorithms::Point3F(2.0, 2.0, 2.0), 1.6)};
-    particleVector[0].velocity = SPHAlgorithms::Point3F(2.0, 2.0, 2.0);
-    particleVector[1].velocity = SPHAlgorithms::Point3F(-2.0, 2.0, 2.0);
-    particleVector[2].velocity = SPHAlgorithms::Point3F(0.0, -2.0, 0.0);
+    ParticleVect particleVector = {Particle(Point3F(1.0, 1.0, 1.0), 1.6),
+                                   Particle(Point3F(3.0, 1.0, 1.0), 1.6),
+                                   Particle(Point3F(2.0, 2.0, 2.0), 1.6)};
+    particleVector[0].velocity = Point3F(2.0, 2.0, 2.0);
+    particleVector[1].velocity = Point3F(-2.0, 2.0, 2.0);
+    particleVector[2].velocity = Point3F(0.0, -2.0, 0.0);
     particleVector[0].neighbours = {1, 2};
     particleVector[1].neighbours = {0, 2};
     particleVector[2].neighbours = {0, 1};
 
-    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3F(0.0, 0.0, 0.0), 4.0, 4.0, 4.0));
+    Volume volume(Cuboid(Point3F(0.0, 0.0, 0.0), 4.0, 4.0, 4.0));
 
     Collision::detectCollisions(particleVector, volume);
 
@@ -83,18 +83,18 @@ void CollisionsTestSuite::threeParticleCollision()
 void CollisionsTestSuite::fourParticleCollision()
 {
     ParticleVect particleVector = {
-        Particle(SPHAlgorithms::Point3F(1.0, 1.0, 1.0), 1.6), Particle(SPHAlgorithms::Point3F(3.0, 1.0, 1.0), 1.6),
-        Particle(SPHAlgorithms::Point3F(1.0, 3.0, 1.0), 1.6), Particle(SPHAlgorithms::Point3F(3.0, 3.0, 3.0), 1.6)};
-    particleVector[0].velocity = SPHAlgorithms::Point3F(2.0, 2.0, 2.0);
-    particleVector[1].velocity = SPHAlgorithms::Point3F(-2.0, 2.0, 2.0);
-    particleVector[2].velocity = SPHAlgorithms::Point3F(2.0, -2.0, 2.0);
-    particleVector[3].velocity = SPHAlgorithms::Point3F(-2.0, -2.0, 2.0);
+        Particle(Point3F(1.0, 1.0, 1.0), 1.6), Particle(Point3F(3.0, 1.0, 1.0), 1.6),
+        Particle(Point3F(1.0, 3.0, 1.0), 1.6), Particle(Point3F(3.0, 3.0, 3.0), 1.6)};
+    particleVector[0].velocity = Point3F(2.0, 2.0, 2.0);
+    particleVector[1].velocity = Point3F(-2.0, 2.0, 2.0);
+    particleVector[2].velocity = Point3F(2.0, -2.0, 2.0);
+    particleVector[3].velocity = Point3F(-2.0, -2.0, 2.0);
     particleVector[0].neighbours = {1, 2, 3};
     particleVector[1].neighbours = {0, 2, 3};
     particleVector[2].neighbours = {0, 1, 3};
     particleVector[3].neighbours = {0, 1, 2};
 
-    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3F(0.0, 0.0, 0.0), 4.0, 4.0, 4.0));
+    Volume volume(Cuboid(Point3F(0.0, 0.0, 0.0), 4.0, 4.0, 4.0));
 
     Collision::detectCollisions(particleVector, volume);
 
@@ -128,18 +128,18 @@ void CollisionsTestSuite::fourParticleCollision()
 void CollisionsTestSuite::twoAndTwoParticleCollision()
 {
     ParticleVect particleVector = {
-        Particle(SPHAlgorithms::Point3F(1.0, 1.0, 1.0), 0.55), Particle(SPHAlgorithms::Point3F(1.5, 1.0, 1.0), 0.55),
-        Particle(SPHAlgorithms::Point3F(1.0, 3.0, 3.0), 0.55), Particle(SPHAlgorithms::Point3F(1.5, 3.0, 3.0), 0.55)};
-    particleVector[0].velocity = SPHAlgorithms::Point3F(2.0, 0.0, 1.0);
-    particleVector[1].velocity = SPHAlgorithms::Point3F(-2.0, 0.0, 1.0);
-    particleVector[2].velocity = SPHAlgorithms::Point3F(2.0, 0.0, 1.0);
-    particleVector[3].velocity = SPHAlgorithms::Point3F(-2.0, 0.0, 1.0);
+        Particle(Point3F(1.0, 1.0, 1.0), 0.55), Particle(Point3F(1.5, 1.0, 1.0), 0.55),
+        Particle(Point3F(1.0, 3.0, 3.0), 0.55), Particle(Point3F(1.5, 3.0, 3.0), 0.55)};
+    particleVector[0].velocity = Point3F(2.0, 0.0, 1.0);
+    particleVector[1].velocity = Point3F(-2.0, 0.0, 1.0);
+    particleVector[2].velocity = Point3F(2.0, 0.0, 1.0);
+    particleVector[3].velocity = Point3F(-2.0, 0.0, 1.0);
     particleVector[0].neighbours = {1, 2, 3};
     particleVector[1].neighbours = {0, 2, 3};
     particleVector[2].neighbours = {0, 1, 3};
     particleVector[3].neighbours = {0, 1, 2};
 
-    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3F(0.0, 0.0, 1.0), 4.0, 4.0, 1.0));
+    Volume volume(Cuboid(Point3F(0.0, 0.0, 1.0), 4.0, 4.0, 1.0));
 
     Collision::detectCollisions(particleVector, volume);
 
@@ -160,15 +160,15 @@ void CollisionsTestSuite::twoAndTwoParticleCollision()
 void CollisionsTestSuite::oneAndFiveParticleCollision()
 {
     ParticleVect particleVector = {
-        Particle(SPHAlgorithms::Point3F(1.0, 1.0, 1.0), 0.12), Particle(SPHAlgorithms::Point3F(1.1, 1.0, 1.0), 0.12),
-        Particle(SPHAlgorithms::Point3F(1.2, 1.0, 1.0), 0.12), Particle(SPHAlgorithms::Point3F(1.3, 1.0, 1.0), 0.12),
-        Particle(SPHAlgorithms::Point3F(1.4, 1.0, 1.0), 0.12), Particle(SPHAlgorithms::Point3F(1.5, 1.0, 1.0), 0.12)};
-    particleVector[0].velocity = SPHAlgorithms::Point3F(0.0, 0.0, 1.0);
-    particleVector[1].velocity = SPHAlgorithms::Point3F(0.0, 0.0, 1.0);
-    particleVector[2].velocity = SPHAlgorithms::Point3F(0.0, 0.0, 1.0);
-    particleVector[3].velocity = SPHAlgorithms::Point3F(0.0, 0.0, 1.0);
-    particleVector[4].velocity = SPHAlgorithms::Point3F(0.0, 0.0, 1.0);
-    particleVector[5].velocity = SPHAlgorithms::Point3F(-1.0, 0.0, 1.0);
+        Particle(Point3F(1.0, 1.0, 1.0), 0.12), Particle(Point3F(1.1, 1.0, 1.0), 0.12),
+        Particle(Point3F(1.2, 1.0, 1.0), 0.12), Particle(Point3F(1.3, 1.0, 1.0), 0.12),
+        Particle(Point3F(1.4, 1.0, 1.0), 0.12), Particle(Point3F(1.5, 1.0, 1.0), 0.12)};
+    particleVector[0].velocity = Point3F(0.0, 0.0, 1.0);
+    particleVector[1].velocity = Point3F(0.0, 0.0, 1.0);
+    particleVector[2].velocity = Point3F(0.0, 0.0, 1.0);
+    particleVector[3].velocity = Point3F(0.0, 0.0, 1.0);
+    particleVector[4].velocity = Point3F(0.0, 0.0, 1.0);
+    particleVector[5].velocity = Point3F(-1.0, 0.0, 1.0);
     particleVector[0].neighbours = {1};
     particleVector[1].neighbours = {0, 2};
     particleVector[2].neighbours = {1, 3};
@@ -176,7 +176,7 @@ void CollisionsTestSuite::oneAndFiveParticleCollision()
     particleVector[4].neighbours = {3, 5};
     particleVector[5].neighbours = {4};
 
-    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3F(0.0, 0.0, 1.0), 4.0, 4.0, 1.0));
+    Volume volume(Cuboid(Point3F(0.0, 0.0, 1.0), 4.0, 4.0, 1.0));
 
     Collision::detectCollisions(particleVector, volume);
 
@@ -203,21 +203,21 @@ void CollisionsTestSuite::oneAndFiveParticleCollision()
 void CollisionsTestSuite::oneAndFourParticleCollision()
 {
     ParticleVect particleVector = {
-        Particle(SPHAlgorithms::Point3F(1.0, 1.0, 1.0), 0.12), Particle(SPHAlgorithms::Point3F(1.1, 1.0, 1.0), 0.12),
-        Particle(SPHAlgorithms::Point3F(1.2, 1.0, 1.0), 0.12), Particle(SPHAlgorithms::Point3F(1.3, 1.0, 1.0), 0.12),
-        Particle(SPHAlgorithms::Point3F(1.25, 1.1, 1.0), 0.12)};
-    particleVector[0].velocity = SPHAlgorithms::Point3F(0.0, 0.0, 1.0);
-    particleVector[1].velocity = SPHAlgorithms::Point3F(0.0, 0.0, 1.0);
-    particleVector[2].velocity = SPHAlgorithms::Point3F(0.0, 0.0, 1.0);
-    particleVector[3].velocity = SPHAlgorithms::Point3F(0.0, 0.0, 1.0);
-    particleVector[4].velocity = SPHAlgorithms::Point3F(0.0, 5.0, 1.0);
+        Particle(Point3F(1.0, 1.0, 1.0), 0.12), Particle(Point3F(1.1, 1.0, 1.0), 0.12),
+        Particle(Point3F(1.2, 1.0, 1.0), 0.12), Particle(Point3F(1.3, 1.0, 1.0), 0.12),
+        Particle(Point3F(1.25, 1.1, 1.0), 0.12)};
+    particleVector[0].velocity = Point3F(0.0, 0.0, 1.0);
+    particleVector[1].velocity = Point3F(0.0, 0.0, 1.0);
+    particleVector[2].velocity = Point3F(0.0, 0.0, 1.0);
+    particleVector[3].velocity = Point3F(0.0, 0.0, 1.0);
+    particleVector[4].velocity = Point3F(0.0, 5.0, 1.0);
     particleVector[0].neighbours = {1};
     particleVector[1].neighbours = {0, 2, 4};
     particleVector[2].neighbours = {1, 3, 4};
     particleVector[3].neighbours = {2};
     particleVector[4].neighbours = {1, 2};
 
-    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3F(0.0, 0.0, 1.0), 4.0, 4.0, 1.0));
+    Volume volume(Cuboid(Point3F(0.0, 0.0, 1.0), 4.0, 4.0, 1.0));
 
     Collision::detectCollisions(particleVector, volume);
 
@@ -241,20 +241,20 @@ void CollisionsTestSuite::oneAndFourParticleCollision()
 void CollisionsTestSuite::oneAndEightParticleCollision()
 {
     ParticleVect particleVector = {
-        Particle(SPHAlgorithms::Point3F(1.0, 1.0, 1.0), 0.51), Particle(SPHAlgorithms::Point3F(0.75, 1.25, 1.0), 0.51),
-        Particle(SPHAlgorithms::Point3F(0.5, 1.5, 1.0), 0.51), Particle(SPHAlgorithms::Point3F(0.75, 1.75, 1.0), 0.51),
-        Particle(SPHAlgorithms::Point3F(1.0, 2.0, 1.0), 0.51), Particle(SPHAlgorithms::Point3F(1.25, 1.75, 1.0), 0.51),
-        Particle(SPHAlgorithms::Point3F(1.5, 1.5, 1.0), 0.51), Particle(SPHAlgorithms::Point3F(1.25, 1.25, 1.0), 0.51),
-        Particle(SPHAlgorithms::Point3F(1.0, 1.5, 1.0), 0.51)};
-    particleVector[0].velocity = SPHAlgorithms::Point3F(0.0, 1.0, 1.0);
-    particleVector[1].velocity = SPHAlgorithms::Point3F(1.0, 1.0, 1.0);
-    particleVector[2].velocity = SPHAlgorithms::Point3F(1.0, 0.0, 1.0);
-    particleVector[3].velocity = SPHAlgorithms::Point3F(1.0, -1.0, 1.0);
-    particleVector[4].velocity = SPHAlgorithms::Point3F(0.0, -1.0, 1.0);
-    particleVector[5].velocity = SPHAlgorithms::Point3F(-1.0, -1.0, 1.0);
-    particleVector[6].velocity = SPHAlgorithms::Point3F(-1.0, 0.0, 1.0);
-    particleVector[7].velocity = SPHAlgorithms::Point3F(-1.0, 1.0, 1.0);
-    particleVector[8].velocity = SPHAlgorithms::Point3F(0.0, 0.0, 1.0);
+        Particle(Point3F(1.0, 1.0, 1.0), 0.51), Particle(Point3F(0.75, 1.25, 1.0), 0.51),
+        Particle(Point3F(0.5, 1.5, 1.0), 0.51), Particle(Point3F(0.75, 1.75, 1.0), 0.51),
+        Particle(Point3F(1.0, 2.0, 1.0), 0.51), Particle(Point3F(1.25, 1.75, 1.0), 0.51),
+        Particle(Point3F(1.5, 1.5, 1.0), 0.51), Particle(Point3F(1.25, 1.25, 1.0), 0.51),
+        Particle(Point3F(1.0, 1.5, 1.0), 0.51)};
+    particleVector[0].velocity = Point3F(0.0, 1.0, 1.0);
+    particleVector[1].velocity = Point3F(1.0, 1.0, 1.0);
+    particleVector[2].velocity = Point3F(1.0, 0.0, 1.0);
+    particleVector[3].velocity = Point3F(1.0, -1.0, 1.0);
+    particleVector[4].velocity = Point3F(0.0, -1.0, 1.0);
+    particleVector[5].velocity = Point3F(-1.0, -1.0, 1.0);
+    particleVector[6].velocity = Point3F(-1.0, 0.0, 1.0);
+    particleVector[7].velocity = Point3F(-1.0, 1.0, 1.0);
+    particleVector[8].velocity = Point3F(0.0, 0.0, 1.0);
     particleVector[0].neighbours = {1, 7, 8};
     particleVector[1].neighbours = {0, 2, 8};
     particleVector[2].neighbours = {1, 3, 8};
@@ -265,7 +265,7 @@ void CollisionsTestSuite::oneAndEightParticleCollision()
     particleVector[7].neighbours = {0, 6, 8};
     particleVector[8].neighbours = {0, 1, 2, 3, 4, 5, 6, 7};
 
-    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3F(0.0, 0.0, 0.0), 4.0, 4.0, 1.0));
+    Volume volume(Cuboid(Point3F(0.0, 0.0, 0.0), 4.0, 4.0, 1.0));
 
     Collision::detectCollisions(particleVector, volume);
 
@@ -300,9 +300,9 @@ void CollisionsTestSuite::oneAndEightParticleCollision()
 
 void CollisionsTestSuite::oneOnBoundaryParticleCollision()
 {
-    ParticleVect particleVector = {Particle(SPHAlgorithms::Point3F(-9.83, -0.003716, -1.0), 0.1)};
-    particleVector[0].velocity = SPHAlgorithms::Point3F(-0.5, -7.0, -1.0);
-    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3F(0.0, 0.0, -1.0), 10.0, 10.0, 10.0));
+    ParticleVect particleVector = {Particle(Point3F(-9.83, -0.003716, -1.0), 0.1)};
+    particleVector[0].velocity = Point3F(-0.5, -7.0, -1.0);
+    Volume volume(Cuboid(Point3F(0.0, 0.0, -1.0), 10.0, 10.0, 10.0));
 
     Collision::detectCollisions(particleVector, volume);
 
@@ -317,14 +317,14 @@ void CollisionsTestSuite::oneOnBoundaryParticleCollision()
 
 void CollisionsTestSuite::twoOnBoundaryParticleCollision()
 {
-    ParticleVect particleVector = {Particle(SPHAlgorithms::Point3F(0.0, -0.5, 1.0), 0.1),
-                                   Particle(SPHAlgorithms::Point3F(0.01, -0.5, 1.0), 0.1)};
-    particleVector[0].velocity = SPHAlgorithms::Point3F(1.0, -1.0, 1.0);
-    particleVector[1].velocity = SPHAlgorithms::Point3F(-1.0, -1.0, 1.0);
+    ParticleVect particleVector = {Particle(Point3F(0.0, -0.5, 1.0), 0.1),
+                                   Particle(Point3F(0.01, -0.5, 1.0), 0.1)};
+    particleVector[0].velocity = Point3F(1.0, -1.0, 1.0);
+    particleVector[1].velocity = Point3F(-1.0, -1.0, 1.0);
     particleVector[0].neighbours = {1};
     particleVector[1].neighbours = {0};
 
-    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3F(0.0, 0.0, 0.0), 2.0, 2.0, 2.0));
+    Volume volume(Cuboid(Point3F(0.0, 0.0, 0.0), 2.0, 2.0, 2.0));
 
     Collision::detectCollisions(particleVector, volume);
 
@@ -338,14 +338,14 @@ void CollisionsTestSuite::twoOnBoundaryParticleCollision()
 
 void CollisionsTestSuite::threeOnBoundaryParticleCollision()
 {
-    ParticleVect particleVector = {Particle(SPHAlgorithms::Point3F(-0.1, 0.0, 1.0), 0.1),
-                                   Particle(SPHAlgorithms::Point3F(-0.1, 0.2, 1.0), 0.1),
-                                   Particle(SPHAlgorithms::Point3F(-0.1, 0.4, 1.0), 0.1)};
-    particleVector[0].velocity = SPHAlgorithms::Point3F(-1.0, 0.0, 1.0);
-    particleVector[1].velocity = SPHAlgorithms::Point3F(-1.0, 0.0, 1.0);
-    particleVector[2].velocity = SPHAlgorithms::Point3F(-1.0, 0.0, 1.0);
+    ParticleVect particleVector = {Particle(Point3F(-0.1, 0.0, 1.0), 0.1),
+                                   Particle(Point3F(-0.1, 0.2, 1.0), 0.1),
+                                   Particle(Point3F(-0.1, 0.4, 1.0), 0.1)};
+    particleVector[0].velocity = Point3F(-1.0, 0.0, 1.0);
+    particleVector[1].velocity = Point3F(-1.0, 0.0, 1.0);
+    particleVector[2].velocity = Point3F(-1.0, 0.0, 1.0);
 
-    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3F(0.0, 0.0, 0.0), 2.0, 2.0, 2.0));
+    Volume volume(Cuboid(Point3F(0.0, 0.0, 0.0), 2.0, 2.0, 2.0));
 
     Collision::detectCollisions(particleVector, volume);
 

--- a/sph/test/src/CollisionsTestSuite.cpp
+++ b/sph/test/src/CollisionsTestSuite.cpp
@@ -18,13 +18,13 @@ namespace TestEnvironment
 
 void CollisionsTestSuite::twoParticleCollision()
 {
-    ParticleVect particleVector = {Particle(SPHAlgorithms::Point3D(0.01, 0.01, 0.01), 0.1),
-                                   Particle(SPHAlgorithms::Point3D(0.09, 0.09, 0.09), 0.1)};
-    particleVector[0].velocity = SPHAlgorithms::Point3D(2.0, 2.0, 2.0);
-    particleVector[1].velocity = SPHAlgorithms::Point3D(-2.0, -2.0, -2.0);
+    ParticleVect particleVector = {Particle(SPHAlgorithms::Point3F(0.01, 0.01, 0.01), 0.1),
+                                   Particle(SPHAlgorithms::Point3F(0.09, 0.09, 0.09), 0.1)};
+    particleVector[0].velocity = SPHAlgorithms::Point3F(2.0, 2.0, 2.0);
+    particleVector[1].velocity = SPHAlgorithms::Point3F(-2.0, -2.0, -2.0);
     particleVector[0].neighbours = {1};
     particleVector[1].neighbours = {0};
-    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3D(0.0, 0.0, 0.0), 1.0, 1.0, 1.0));
+    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3F(0.0, 0.0, 0.0), 1.0, 1.0, 1.0));
 
     Collision::detectCollisions(particleVector, volume);
 
@@ -45,17 +45,17 @@ void CollisionsTestSuite::twoParticleCollision()
 
 void CollisionsTestSuite::threeParticleCollision()
 {
-    ParticleVect particleVector = {Particle(SPHAlgorithms::Point3D(1.0, 1.0, 1.0), 1.6),
-                                   Particle(SPHAlgorithms::Point3D(3.0, 1.0, 1.0), 1.6),
-                                   Particle(SPHAlgorithms::Point3D(2.0, 2.0, 2.0), 1.6)};
-    particleVector[0].velocity = SPHAlgorithms::Point3D(2.0, 2.0, 2.0);
-    particleVector[1].velocity = SPHAlgorithms::Point3D(-2.0, 2.0, 2.0);
-    particleVector[2].velocity = SPHAlgorithms::Point3D(0.0, -2.0, 0.0);
+    ParticleVect particleVector = {Particle(SPHAlgorithms::Point3F(1.0, 1.0, 1.0), 1.6),
+                                   Particle(SPHAlgorithms::Point3F(3.0, 1.0, 1.0), 1.6),
+                                   Particle(SPHAlgorithms::Point3F(2.0, 2.0, 2.0), 1.6)};
+    particleVector[0].velocity = SPHAlgorithms::Point3F(2.0, 2.0, 2.0);
+    particleVector[1].velocity = SPHAlgorithms::Point3F(-2.0, 2.0, 2.0);
+    particleVector[2].velocity = SPHAlgorithms::Point3F(0.0, -2.0, 0.0);
     particleVector[0].neighbours = {1, 2};
     particleVector[1].neighbours = {0, 2};
     particleVector[2].neighbours = {0, 1};
 
-    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3D(0.0, 0.0, 0.0), 4.0, 4.0, 4.0));
+    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3F(0.0, 0.0, 0.0), 4.0, 4.0, 4.0));
 
     Collision::detectCollisions(particleVector, volume);
 
@@ -83,18 +83,18 @@ void CollisionsTestSuite::threeParticleCollision()
 void CollisionsTestSuite::fourParticleCollision()
 {
     ParticleVect particleVector = {
-        Particle(SPHAlgorithms::Point3D(1.0, 1.0, 1.0), 1.6), Particle(SPHAlgorithms::Point3D(3.0, 1.0, 1.0), 1.6),
-        Particle(SPHAlgorithms::Point3D(1.0, 3.0, 1.0), 1.6), Particle(SPHAlgorithms::Point3D(3.0, 3.0, 3.0), 1.6)};
-    particleVector[0].velocity = SPHAlgorithms::Point3D(2.0, 2.0, 2.0);
-    particleVector[1].velocity = SPHAlgorithms::Point3D(-2.0, 2.0, 2.0);
-    particleVector[2].velocity = SPHAlgorithms::Point3D(2.0, -2.0, 2.0);
-    particleVector[3].velocity = SPHAlgorithms::Point3D(-2.0, -2.0, 2.0);
+        Particle(SPHAlgorithms::Point3F(1.0, 1.0, 1.0), 1.6), Particle(SPHAlgorithms::Point3F(3.0, 1.0, 1.0), 1.6),
+        Particle(SPHAlgorithms::Point3F(1.0, 3.0, 1.0), 1.6), Particle(SPHAlgorithms::Point3F(3.0, 3.0, 3.0), 1.6)};
+    particleVector[0].velocity = SPHAlgorithms::Point3F(2.0, 2.0, 2.0);
+    particleVector[1].velocity = SPHAlgorithms::Point3F(-2.0, 2.0, 2.0);
+    particleVector[2].velocity = SPHAlgorithms::Point3F(2.0, -2.0, 2.0);
+    particleVector[3].velocity = SPHAlgorithms::Point3F(-2.0, -2.0, 2.0);
     particleVector[0].neighbours = {1, 2, 3};
     particleVector[1].neighbours = {0, 2, 3};
     particleVector[2].neighbours = {0, 1, 3};
     particleVector[3].neighbours = {0, 1, 2};
 
-    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3D(0.0, 0.0, 0.0), 4.0, 4.0, 4.0));
+    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3F(0.0, 0.0, 0.0), 4.0, 4.0, 4.0));
 
     Collision::detectCollisions(particleVector, volume);
 
@@ -128,18 +128,18 @@ void CollisionsTestSuite::fourParticleCollision()
 void CollisionsTestSuite::twoAndTwoParticleCollision()
 {
     ParticleVect particleVector = {
-        Particle(SPHAlgorithms::Point3D(1.0, 1.0, 1.0), 0.55), Particle(SPHAlgorithms::Point3D(1.5, 1.0, 1.0), 0.55),
-        Particle(SPHAlgorithms::Point3D(1.0, 3.0, 3.0), 0.55), Particle(SPHAlgorithms::Point3D(1.5, 3.0, 3.0), 0.55)};
-    particleVector[0].velocity = SPHAlgorithms::Point3D(2.0, 0.0, 1.0);
-    particleVector[1].velocity = SPHAlgorithms::Point3D(-2.0, 0.0, 1.0);
-    particleVector[2].velocity = SPHAlgorithms::Point3D(2.0, 0.0, 1.0);
-    particleVector[3].velocity = SPHAlgorithms::Point3D(-2.0, 0.0, 1.0);
+        Particle(SPHAlgorithms::Point3F(1.0, 1.0, 1.0), 0.55), Particle(SPHAlgorithms::Point3F(1.5, 1.0, 1.0), 0.55),
+        Particle(SPHAlgorithms::Point3F(1.0, 3.0, 3.0), 0.55), Particle(SPHAlgorithms::Point3F(1.5, 3.0, 3.0), 0.55)};
+    particleVector[0].velocity = SPHAlgorithms::Point3F(2.0, 0.0, 1.0);
+    particleVector[1].velocity = SPHAlgorithms::Point3F(-2.0, 0.0, 1.0);
+    particleVector[2].velocity = SPHAlgorithms::Point3F(2.0, 0.0, 1.0);
+    particleVector[3].velocity = SPHAlgorithms::Point3F(-2.0, 0.0, 1.0);
     particleVector[0].neighbours = {1, 2, 3};
     particleVector[1].neighbours = {0, 2, 3};
     particleVector[2].neighbours = {0, 1, 3};
     particleVector[3].neighbours = {0, 1, 2};
 
-    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3D(0.0, 0.0, 1.0), 4.0, 4.0, 1.0));
+    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3F(0.0, 0.0, 1.0), 4.0, 4.0, 1.0));
 
     Collision::detectCollisions(particleVector, volume);
 
@@ -160,15 +160,15 @@ void CollisionsTestSuite::twoAndTwoParticleCollision()
 void CollisionsTestSuite::oneAndFiveParticleCollision()
 {
     ParticleVect particleVector = {
-        Particle(SPHAlgorithms::Point3D(1.0, 1.0, 1.0), 0.12), Particle(SPHAlgorithms::Point3D(1.1, 1.0, 1.0), 0.12),
-        Particle(SPHAlgorithms::Point3D(1.2, 1.0, 1.0), 0.12), Particle(SPHAlgorithms::Point3D(1.3, 1.0, 1.0), 0.12),
-        Particle(SPHAlgorithms::Point3D(1.4, 1.0, 1.0), 0.12), Particle(SPHAlgorithms::Point3D(1.5, 1.0, 1.0), 0.12)};
-    particleVector[0].velocity = SPHAlgorithms::Point3D(0.0, 0.0, 1.0);
-    particleVector[1].velocity = SPHAlgorithms::Point3D(0.0, 0.0, 1.0);
-    particleVector[2].velocity = SPHAlgorithms::Point3D(0.0, 0.0, 1.0);
-    particleVector[3].velocity = SPHAlgorithms::Point3D(0.0, 0.0, 1.0);
-    particleVector[4].velocity = SPHAlgorithms::Point3D(0.0, 0.0, 1.0);
-    particleVector[5].velocity = SPHAlgorithms::Point3D(-1.0, 0.0, 1.0);
+        Particle(SPHAlgorithms::Point3F(1.0, 1.0, 1.0), 0.12), Particle(SPHAlgorithms::Point3F(1.1, 1.0, 1.0), 0.12),
+        Particle(SPHAlgorithms::Point3F(1.2, 1.0, 1.0), 0.12), Particle(SPHAlgorithms::Point3F(1.3, 1.0, 1.0), 0.12),
+        Particle(SPHAlgorithms::Point3F(1.4, 1.0, 1.0), 0.12), Particle(SPHAlgorithms::Point3F(1.5, 1.0, 1.0), 0.12)};
+    particleVector[0].velocity = SPHAlgorithms::Point3F(0.0, 0.0, 1.0);
+    particleVector[1].velocity = SPHAlgorithms::Point3F(0.0, 0.0, 1.0);
+    particleVector[2].velocity = SPHAlgorithms::Point3F(0.0, 0.0, 1.0);
+    particleVector[3].velocity = SPHAlgorithms::Point3F(0.0, 0.0, 1.0);
+    particleVector[4].velocity = SPHAlgorithms::Point3F(0.0, 0.0, 1.0);
+    particleVector[5].velocity = SPHAlgorithms::Point3F(-1.0, 0.0, 1.0);
     particleVector[0].neighbours = {1};
     particleVector[1].neighbours = {0, 2};
     particleVector[2].neighbours = {1, 3};
@@ -176,7 +176,7 @@ void CollisionsTestSuite::oneAndFiveParticleCollision()
     particleVector[4].neighbours = {3, 5};
     particleVector[5].neighbours = {4};
 
-    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3D(0.0, 0.0, 1.0), 4.0, 4.0, 1.0));
+    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3F(0.0, 0.0, 1.0), 4.0, 4.0, 1.0));
 
     Collision::detectCollisions(particleVector, volume);
 
@@ -203,21 +203,21 @@ void CollisionsTestSuite::oneAndFiveParticleCollision()
 void CollisionsTestSuite::oneAndFourParticleCollision()
 {
     ParticleVect particleVector = {
-        Particle(SPHAlgorithms::Point3D(1.0, 1.0, 1.0), 0.12), Particle(SPHAlgorithms::Point3D(1.1, 1.0, 1.0), 0.12),
-        Particle(SPHAlgorithms::Point3D(1.2, 1.0, 1.0), 0.12), Particle(SPHAlgorithms::Point3D(1.3, 1.0, 1.0), 0.12),
-        Particle(SPHAlgorithms::Point3D(1.25, 1.1, 1.0), 0.12)};
-    particleVector[0].velocity = SPHAlgorithms::Point3D(0.0, 0.0, 1.0);
-    particleVector[1].velocity = SPHAlgorithms::Point3D(0.0, 0.0, 1.0);
-    particleVector[2].velocity = SPHAlgorithms::Point3D(0.0, 0.0, 1.0);
-    particleVector[3].velocity = SPHAlgorithms::Point3D(0.0, 0.0, 1.0);
-    particleVector[4].velocity = SPHAlgorithms::Point3D(0.0, 5.0, 1.0);
+        Particle(SPHAlgorithms::Point3F(1.0, 1.0, 1.0), 0.12), Particle(SPHAlgorithms::Point3F(1.1, 1.0, 1.0), 0.12),
+        Particle(SPHAlgorithms::Point3F(1.2, 1.0, 1.0), 0.12), Particle(SPHAlgorithms::Point3F(1.3, 1.0, 1.0), 0.12),
+        Particle(SPHAlgorithms::Point3F(1.25, 1.1, 1.0), 0.12)};
+    particleVector[0].velocity = SPHAlgorithms::Point3F(0.0, 0.0, 1.0);
+    particleVector[1].velocity = SPHAlgorithms::Point3F(0.0, 0.0, 1.0);
+    particleVector[2].velocity = SPHAlgorithms::Point3F(0.0, 0.0, 1.0);
+    particleVector[3].velocity = SPHAlgorithms::Point3F(0.0, 0.0, 1.0);
+    particleVector[4].velocity = SPHAlgorithms::Point3F(0.0, 5.0, 1.0);
     particleVector[0].neighbours = {1};
     particleVector[1].neighbours = {0, 2, 4};
     particleVector[2].neighbours = {1, 3, 4};
     particleVector[3].neighbours = {2};
     particleVector[4].neighbours = {1, 2};
 
-    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3D(0.0, 0.0, 1.0), 4.0, 4.0, 1.0));
+    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3F(0.0, 0.0, 1.0), 4.0, 4.0, 1.0));
 
     Collision::detectCollisions(particleVector, volume);
 
@@ -241,20 +241,20 @@ void CollisionsTestSuite::oneAndFourParticleCollision()
 void CollisionsTestSuite::oneAndEightParticleCollision()
 {
     ParticleVect particleVector = {
-        Particle(SPHAlgorithms::Point3D(1.0, 1.0, 1.0), 0.51), Particle(SPHAlgorithms::Point3D(0.75, 1.25, 1.0), 0.51),
-        Particle(SPHAlgorithms::Point3D(0.5, 1.5, 1.0), 0.51), Particle(SPHAlgorithms::Point3D(0.75, 1.75, 1.0), 0.51),
-        Particle(SPHAlgorithms::Point3D(1.0, 2.0, 1.0), 0.51), Particle(SPHAlgorithms::Point3D(1.25, 1.75, 1.0), 0.51),
-        Particle(SPHAlgorithms::Point3D(1.5, 1.5, 1.0), 0.51), Particle(SPHAlgorithms::Point3D(1.25, 1.25, 1.0), 0.51),
-        Particle(SPHAlgorithms::Point3D(1.0, 1.5, 1.0), 0.51)};
-    particleVector[0].velocity = SPHAlgorithms::Point3D(0.0, 1.0, 1.0);
-    particleVector[1].velocity = SPHAlgorithms::Point3D(1.0, 1.0, 1.0);
-    particleVector[2].velocity = SPHAlgorithms::Point3D(1.0, 0.0, 1.0);
-    particleVector[3].velocity = SPHAlgorithms::Point3D(1.0, -1.0, 1.0);
-    particleVector[4].velocity = SPHAlgorithms::Point3D(0.0, -1.0, 1.0);
-    particleVector[5].velocity = SPHAlgorithms::Point3D(-1.0, -1.0, 1.0);
-    particleVector[6].velocity = SPHAlgorithms::Point3D(-1.0, 0.0, 1.0);
-    particleVector[7].velocity = SPHAlgorithms::Point3D(-1.0, 1.0, 1.0);
-    particleVector[8].velocity = SPHAlgorithms::Point3D(0.0, 0.0, 1.0);
+        Particle(SPHAlgorithms::Point3F(1.0, 1.0, 1.0), 0.51), Particle(SPHAlgorithms::Point3F(0.75, 1.25, 1.0), 0.51),
+        Particle(SPHAlgorithms::Point3F(0.5, 1.5, 1.0), 0.51), Particle(SPHAlgorithms::Point3F(0.75, 1.75, 1.0), 0.51),
+        Particle(SPHAlgorithms::Point3F(1.0, 2.0, 1.0), 0.51), Particle(SPHAlgorithms::Point3F(1.25, 1.75, 1.0), 0.51),
+        Particle(SPHAlgorithms::Point3F(1.5, 1.5, 1.0), 0.51), Particle(SPHAlgorithms::Point3F(1.25, 1.25, 1.0), 0.51),
+        Particle(SPHAlgorithms::Point3F(1.0, 1.5, 1.0), 0.51)};
+    particleVector[0].velocity = SPHAlgorithms::Point3F(0.0, 1.0, 1.0);
+    particleVector[1].velocity = SPHAlgorithms::Point3F(1.0, 1.0, 1.0);
+    particleVector[2].velocity = SPHAlgorithms::Point3F(1.0, 0.0, 1.0);
+    particleVector[3].velocity = SPHAlgorithms::Point3F(1.0, -1.0, 1.0);
+    particleVector[4].velocity = SPHAlgorithms::Point3F(0.0, -1.0, 1.0);
+    particleVector[5].velocity = SPHAlgorithms::Point3F(-1.0, -1.0, 1.0);
+    particleVector[6].velocity = SPHAlgorithms::Point3F(-1.0, 0.0, 1.0);
+    particleVector[7].velocity = SPHAlgorithms::Point3F(-1.0, 1.0, 1.0);
+    particleVector[8].velocity = SPHAlgorithms::Point3F(0.0, 0.0, 1.0);
     particleVector[0].neighbours = {1, 7, 8};
     particleVector[1].neighbours = {0, 2, 8};
     particleVector[2].neighbours = {1, 3, 8};
@@ -265,7 +265,7 @@ void CollisionsTestSuite::oneAndEightParticleCollision()
     particleVector[7].neighbours = {0, 6, 8};
     particleVector[8].neighbours = {0, 1, 2, 3, 4, 5, 6, 7};
 
-    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3D(0.0, 0.0, 0.0), 4.0, 4.0, 1.0));
+    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3F(0.0, 0.0, 0.0), 4.0, 4.0, 1.0));
 
     Collision::detectCollisions(particleVector, volume);
 
@@ -300,9 +300,9 @@ void CollisionsTestSuite::oneAndEightParticleCollision()
 
 void CollisionsTestSuite::oneOnBoundaryParticleCollision()
 {
-    ParticleVect particleVector = {Particle(SPHAlgorithms::Point3D(-9.83, -0.003716, -1.0), 0.1)};
-    particleVector[0].velocity = SPHAlgorithms::Point3D(-0.5, -7.0, -1.0);
-    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3D(0.0, 0.0, -1.0), 10.0, 10.0, 10.0));
+    ParticleVect particleVector = {Particle(SPHAlgorithms::Point3F(-9.83, -0.003716, -1.0), 0.1)};
+    particleVector[0].velocity = SPHAlgorithms::Point3F(-0.5, -7.0, -1.0);
+    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3F(0.0, 0.0, -1.0), 10.0, 10.0, 10.0));
 
     Collision::detectCollisions(particleVector, volume);
 
@@ -317,14 +317,14 @@ void CollisionsTestSuite::oneOnBoundaryParticleCollision()
 
 void CollisionsTestSuite::twoOnBoundaryParticleCollision()
 {
-    ParticleVect particleVector = {Particle(SPHAlgorithms::Point3D(0.0, -0.5, 1.0), 0.1),
-                                   Particle(SPHAlgorithms::Point3D(0.01, -0.5, 1.0), 0.1)};
-    particleVector[0].velocity = SPHAlgorithms::Point3D(1.0, -1.0, 1.0);
-    particleVector[1].velocity = SPHAlgorithms::Point3D(-1.0, -1.0, 1.0);
+    ParticleVect particleVector = {Particle(SPHAlgorithms::Point3F(0.0, -0.5, 1.0), 0.1),
+                                   Particle(SPHAlgorithms::Point3F(0.01, -0.5, 1.0), 0.1)};
+    particleVector[0].velocity = SPHAlgorithms::Point3F(1.0, -1.0, 1.0);
+    particleVector[1].velocity = SPHAlgorithms::Point3F(-1.0, -1.0, 1.0);
     particleVector[0].neighbours = {1};
     particleVector[1].neighbours = {0};
 
-    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3D(0.0, 0.0, 0.0), 2.0, 2.0, 2.0));
+    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3F(0.0, 0.0, 0.0), 2.0, 2.0, 2.0));
 
     Collision::detectCollisions(particleVector, volume);
 
@@ -338,14 +338,14 @@ void CollisionsTestSuite::twoOnBoundaryParticleCollision()
 
 void CollisionsTestSuite::threeOnBoundaryParticleCollision()
 {
-    ParticleVect particleVector = {Particle(SPHAlgorithms::Point3D(-0.1, 0.0, 1.0), 0.1),
-                                   Particle(SPHAlgorithms::Point3D(-0.1, 0.2, 1.0), 0.1),
-                                   Particle(SPHAlgorithms::Point3D(-0.1, 0.4, 1.0), 0.1)};
-    particleVector[0].velocity = SPHAlgorithms::Point3D(-1.0, 0.0, 1.0);
-    particleVector[1].velocity = SPHAlgorithms::Point3D(-1.0, 0.0, 1.0);
-    particleVector[2].velocity = SPHAlgorithms::Point3D(-1.0, 0.0, 1.0);
+    ParticleVect particleVector = {Particle(SPHAlgorithms::Point3F(-0.1, 0.0, 1.0), 0.1),
+                                   Particle(SPHAlgorithms::Point3F(-0.1, 0.2, 1.0), 0.1),
+                                   Particle(SPHAlgorithms::Point3F(-0.1, 0.4, 1.0), 0.1)};
+    particleVector[0].velocity = SPHAlgorithms::Point3F(-1.0, 0.0, 1.0);
+    particleVector[1].velocity = SPHAlgorithms::Point3F(-1.0, 0.0, 1.0);
+    particleVector[2].velocity = SPHAlgorithms::Point3F(-1.0, 0.0, 1.0);
 
-    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3D(0.0, 0.0, 0.0), 2.0, 2.0, 2.0));
+    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3F(0.0, 0.0, 0.0), 2.0, 2.0, 2.0));
 
     Collision::detectCollisions(particleVector, volume);
 

--- a/sph/test/src/ForcesTestSuite.cpp
+++ b/sph/test/src/ForcesTestSuite.cpp
@@ -28,7 +28,7 @@ static void initGeneralParticles()
 
     for (size_t i = 0; i < numberOfParticles; ++i)
     {
-        generalParticleVect[i] = Particle(Point3F(0.5f + 0.01f * i, 0.5f + 0.01f * i, 0.5f + 0.01f * i), 0.01f);
+        generalParticleVect[i] = Particle(Point3F(0.5 + 0.01 * i, 0.5 + 0.01 * i, 0.5 + 0.01 * i), 0.01);
         generalParticleVect[i].mass = Config::WaterParticleMass;
         generalParticleVect[i].supportRadius = Config::WaterSupportRadius;
     }

--- a/sph/test/src/ForcesTestSuite.cpp
+++ b/sph/test/src/ForcesTestSuite.cpp
@@ -17,7 +17,7 @@ namespace SPHSDK
 namespace TestEnvironment
 {
 
-static const double Precision = 1e-07;
+static const FLOAT Precision = 1e-07;
 static const size_t numberOfParticles = 5;
 
 ParticleVect generalParticleVect = {};
@@ -28,19 +28,19 @@ static void initGeneralParticles()
 
     for (size_t i = 0; i < numberOfParticles; ++i)
     {
-        generalParticleVect[i] = Particle(SPHAlgorithms::Point3F(0.5f + 0.01f * i, 0.5f + 0.01f * i, 0.5f + 0.01f * i), 0.01f);
+        generalParticleVect[i] = Particle(Point3F(0.5f + 0.01f * i, 0.5f + 0.01f * i, 0.5f + 0.01f * i), 0.01f);
         generalParticleVect[i].mass = Config::WaterParticleMass;
         generalParticleVect[i].supportRadius = Config::WaterSupportRadius;
     }
 
-    generalParticleVect[0].velocity = SPHAlgorithms::Point3F(1.0, 1.0, 1.0);
-    generalParticleVect[1].velocity = SPHAlgorithms::Point3F(0.5, 0.5, 0.5);
-    generalParticleVect[2].velocity = SPHAlgorithms::Point3F(0.01, 0.01, 0.01);
-    generalParticleVect[3].velocity = SPHAlgorithms::Point3F(-0.5, -0.5, -0.5);
-    generalParticleVect[4].velocity = SPHAlgorithms::Point3F(-1.0, -1.0, -1.0);
+    generalParticleVect[0].velocity = Point3F(1.0, 1.0, 1.0);
+    generalParticleVect[1].velocity = Point3F(0.5, 0.5, 0.5);
+    generalParticleVect[2].velocity = Point3F(0.01, 0.01, 0.01);
+    generalParticleVect[3].velocity = Point3F(-0.5, -0.5, -0.5);
+    generalParticleVect[4].velocity = Point3F(-1.0, -1.0, -1.0);
 
-    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3F(0.0, 0.0, 0.0), 1.0, 1.0, 1.0));
-    SPHAlgorithms::NeighboursSearch3D<ParticleVect> searcher(volume, Config::WaterSupportRadius, 0.001);
+    Volume volume(Cuboid(Point3F(0.0, 0.0, 0.0), 1.0, 1.0, 1.0));
+    NeighboursSearch3D<ParticleVect> searcher(volume, Config::WaterSupportRadius, 0.001);
     searcher.search(generalParticleVect);
 }
 
@@ -173,8 +173,8 @@ void ForcesTestSuite::externalForcesForFourNeighbours()
 
 void ForcesTestSuite::densityForOneNeighbour()
 {
-    Particle particle1(SPHAlgorithms::Point3F(3.0, 3.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3F(3.0, 3.01, 1.0), 0.01);
+    Particle particle1(Point3F(3.0, 3.0, 1.0), 0.01);
+    Particle particle2(Point3F(3.0, 3.01, 1.0), 0.01);
     particle1.neighbours = {1};
     particle2.neighbours = {0};
 
@@ -188,9 +188,9 @@ void ForcesTestSuite::densityForOneNeighbour()
 
 void ForcesTestSuite::densityForTwoNeighbours()
 {
-    Particle particle1(SPHAlgorithms::Point3F(3.0, 3.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3F(3.0, 3.01, 1.0), 0.01);
-    Particle particle3(SPHAlgorithms::Point3F(3.005, 3.005, 1.0), 0.01);
+    Particle particle1(Point3F(3.0, 3.0, 1.0), 0.01);
+    Particle particle2(Point3F(3.0, 3.01, 1.0), 0.01);
+    Particle particle3(Point3F(3.005, 3.005, 1.0), 0.01);
     particle1.neighbours = {1, 2};
     particle2.neighbours = {0, 2};
     particle3.neighbours = {0, 1};
@@ -206,10 +206,10 @@ void ForcesTestSuite::densityForTwoNeighbours()
 
 void ForcesTestSuite::densityForThreeNeighbours()
 {
-    Particle particle1(SPHAlgorithms::Point3F(3.0, 3.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3F(3.0, 3.01, 1.0), 0.01);
-    Particle particle3(SPHAlgorithms::Point3F(3.005, 3.005, 1.0), 0.01);
-    Particle particle4(SPHAlgorithms::Point3F(2.995, 2.996, 1.0), 0.01);
+    Particle particle1(Point3F(3.0, 3.0, 1.0), 0.01);
+    Particle particle2(Point3F(3.0, 3.01, 1.0), 0.01);
+    Particle particle3(Point3F(3.005, 3.005, 1.0), 0.01);
+    Particle particle4(Point3F(2.995, 2.996, 1.0), 0.01);
     particle1.neighbours = {1, 2, 3};
     particle2.neighbours = {0, 2, 3};
     particle3.neighbours = {0, 1, 3};
@@ -227,8 +227,8 @@ void ForcesTestSuite::densityForThreeNeighbours()
 
 void ForcesTestSuite::pressureForOneNeighbour()
 {
-    Particle particle1(SPHAlgorithms::Point3F(0.0, 0.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3F(0.0, 0.01, 1.0), 0.01);
+    Particle particle1(Point3F(0.0, 0.0, 1.0), 0.01);
+    Particle particle2(Point3F(0.0, 0.01, 1.0), 0.01);
     particle1.neighbours = {1};
     particle2.neighbours = {0};
 
@@ -243,9 +243,9 @@ void ForcesTestSuite::pressureForOneNeighbour()
 
 void ForcesTestSuite::pressureForTwoNeighbours()
 {
-    Particle particle1(SPHAlgorithms::Point3F(3.0, 3.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3F(3.0, 3.01, 1.0), 0.01);
-    Particle particle3(SPHAlgorithms::Point3F(3.005, 3.005, 1.0), 0.01);
+    Particle particle1(Point3F(3.0, 3.0, 1.0), 0.01);
+    Particle particle2(Point3F(3.0, 3.01, 1.0), 0.01);
+    Particle particle3(Point3F(3.005, 3.005, 1.0), 0.01);
     particle1.neighbours = {1, 2};
     particle2.neighbours = {0, 2};
     particle3.neighbours = {0, 1};
@@ -262,10 +262,10 @@ void ForcesTestSuite::pressureForTwoNeighbours()
 
 void ForcesTestSuite::pressureForThreeNeighbours()
 {
-    Particle particle1(SPHAlgorithms::Point3F(3.0, 3.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3F(3.0, 3.01, 1.0), 0.01);
-    Particle particle3(SPHAlgorithms::Point3F(3.005, 3.005, 1.0), 0.01);
-    Particle particle4(SPHAlgorithms::Point3F(2.995, 2.996, 1.0), 0.01);
+    Particle particle1(Point3F(3.0, 3.0, 1.0), 0.01);
+    Particle particle2(Point3F(3.0, 3.01, 1.0), 0.01);
+    Particle particle3(Point3F(3.005, 3.005, 1.0), 0.01);
+    Particle particle4(Point3F(2.995, 2.996, 1.0), 0.01);
     particle1.neighbours = {1, 2, 3};
     particle2.neighbours = {0, 2, 3};
     particle3.neighbours = {0, 1, 3};
@@ -284,10 +284,10 @@ void ForcesTestSuite::pressureForThreeNeighbours()
 
 void ForcesTestSuite::internalForcesForOneNeighbour()
 {
-    Particle particle1(SPHAlgorithms::Point3F(0.0, 0.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3F(0.0, 0.01, 1.0), 0.01);
-    particle1.velocity = SPHAlgorithms::Point3F(0.1, 0.1, 1.0);
-    particle2.velocity = SPHAlgorithms::Point3F(-0.1, -0.1, 1.0);
+    Particle particle1(Point3F(0.0, 0.0, 1.0), 0.01);
+    Particle particle2(Point3F(0.0, 0.01, 1.0), 0.01);
+    particle1.velocity = Point3F(0.1, 0.1, 1.0);
+    particle2.velocity = Point3F(-0.1, -0.1, 1.0);
     particle1.neighbours = {1};
     particle2.neighbours = {0};
 
@@ -321,12 +321,12 @@ void ForcesTestSuite::internalForcesForOneNeighbour()
 
 void ForcesTestSuite::internalForcesForTwoNeighbours()
 {
-    Particle particle1(SPHAlgorithms::Point3F(3.0, 3.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3F(3.0, 3.01, 1.0), 0.01);
-    Particle particle3(SPHAlgorithms::Point3F(3.005, 3.005, 1.0), 0.01);
-    particle1.velocity = SPHAlgorithms::Point3F(0.1, 0.1, 1.0);
-    particle2.velocity = SPHAlgorithms::Point3F(-0.1, -0.1, 1.0);
-    particle3.velocity = SPHAlgorithms::Point3F(0.1, -0.1, 1.0);
+    Particle particle1(Point3F(3.0, 3.0, 1.0), 0.01);
+    Particle particle2(Point3F(3.0, 3.01, 1.0), 0.01);
+    Particle particle3(Point3F(3.005, 3.005, 1.0), 0.01);
+    particle1.velocity = Point3F(0.1, 0.1, 1.0);
+    particle2.velocity = Point3F(-0.1, -0.1, 1.0);
+    particle3.velocity = Point3F(0.1, -0.1, 1.0);
     particle1.neighbours = {1, 2};
     particle2.neighbours = {0, 2};
     particle3.neighbours = {0, 1};
@@ -361,14 +361,14 @@ void ForcesTestSuite::internalForcesForTwoNeighbours()
 
 void ForcesTestSuite::internalForcesForThreeNeighbours()
 {
-    Particle particle1(SPHAlgorithms::Point3F(3.0, 3.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3F(3.0, 3.01, 1.0), 0.01);
-    Particle particle3(SPHAlgorithms::Point3F(3.005, 3.005, 1.0), 0.01);
-    Particle particle4(SPHAlgorithms::Point3F(2.995, 2.996, 1.0), 0.01);
-    particle1.velocity = SPHAlgorithms::Point3F(0.0, 0.1, 1.0);
-    particle2.velocity = SPHAlgorithms::Point3F(0.0, -0.1, 1.0);
-    particle3.velocity = SPHAlgorithms::Point3F(-0.1, -0.1, 1.0);
-    particle3.velocity = SPHAlgorithms::Point3F(0.1, 0.1, 1.0);
+    Particle particle1(Point3F(3.0, 3.0, 1.0), 0.01);
+    Particle particle2(Point3F(3.0, 3.01, 1.0), 0.01);
+    Particle particle3(Point3F(3.005, 3.005, 1.0), 0.01);
+    Particle particle4(Point3F(2.995, 2.996, 1.0), 0.01);
+    particle1.velocity = Point3F(0.0, 0.1, 1.0);
+    particle2.velocity = Point3F(0.0, -0.1, 1.0);
+    particle3.velocity = Point3F(-0.1, -0.1, 1.0);
+    particle3.velocity = Point3F(0.1, 0.1, 1.0);
     particle1.neighbours = {1, 2, 3};
     particle2.neighbours = {0, 2, 3};
     particle3.neighbours = {0, 1, 3};
@@ -410,10 +410,10 @@ void ForcesTestSuite::internalForcesForThreeNeighbours()
 
 void ForcesTestSuite::externalForcesForOneNeighbour()
 {
-    Particle particle1(SPHAlgorithms::Point3F(0.0, 0.0, 0.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3F(0.0, 0.01, 0.0), 0.01);
-    particle1.velocity = SPHAlgorithms::Point3F(0.1, 0.1, 0.1);
-    particle2.velocity = SPHAlgorithms::Point3F(-0.1, -0.1, -0.1);
+    Particle particle1(Point3F(0.0, 0.0, 0.0), 0.01);
+    Particle particle2(Point3F(0.0, 0.01, 0.0), 0.01);
+    particle1.velocity = Point3F(0.1, 0.1, 0.1);
+    particle2.velocity = Point3F(-0.1, -0.1, -0.1);
     particle1.neighbours = {1};
     particle2.neighbours = {0};
 
@@ -442,12 +442,12 @@ void ForcesTestSuite::externalForcesForOneNeighbour()
 
 void ForcesTestSuite::externalForcesForTwoNeighbours()
 {
-    Particle particle1(SPHAlgorithms::Point3F(3.0, 3.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3F(3.0, 3.01, 1.0), 0.01);
-    Particle particle3(SPHAlgorithms::Point3F(3.005, 3.005, 1.0), 0.01);
-    particle1.velocity = SPHAlgorithms::Point3F(0.1, 0.1, 1.0);
-    particle2.velocity = SPHAlgorithms::Point3F(-0.1, -0.1, 1.0);
-    particle3.velocity = SPHAlgorithms::Point3F(0.1, -0.1, 1.0);
+    Particle particle1(Point3F(3.0, 3.0, 1.0), 0.01);
+    Particle particle2(Point3F(3.0, 3.01, 1.0), 0.01);
+    Particle particle3(Point3F(3.005, 3.005, 1.0), 0.01);
+    particle1.velocity = Point3F(0.1, 0.1, 1.0);
+    particle2.velocity = Point3F(-0.1, -0.1, 1.0);
+    particle3.velocity = Point3F(0.1, -0.1, 1.0);
     particle1.neighbours = {1, 2};
     particle2.neighbours = {0, 2};
     particle3.neighbours = {0, 1};
@@ -482,14 +482,14 @@ void ForcesTestSuite::externalForcesForTwoNeighbours()
 
 void ForcesTestSuite::externalForcesForThreeNeighbours()
 {
-    Particle particle1(SPHAlgorithms::Point3F(3.0, 3.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3F(3.0, 3.01, 1.0), 0.01);
-    Particle particle3(SPHAlgorithms::Point3F(3.005, 3.005, 1.0), 0.01);
-    Particle particle4(SPHAlgorithms::Point3F(2.995, 2.996, 1.0), 0.01);
-    particle1.velocity = SPHAlgorithms::Point3F(0.0, 0.1, 1.0);
-    particle2.velocity = SPHAlgorithms::Point3F(0.0, -0.1, 1.0);
-    particle3.velocity = SPHAlgorithms::Point3F(-0.1, -0.1, 1.0);
-    particle4.velocity = SPHAlgorithms::Point3F(0.1, 0.1, 1.0);
+    Particle particle1(Point3F(3.0, 3.0, 1.0), 0.01);
+    Particle particle2(Point3F(3.0, 3.01, 1.0), 0.01);
+    Particle particle3(Point3F(3.005, 3.005, 1.0), 0.01);
+    Particle particle4(Point3F(2.995, 2.996, 1.0), 0.01);
+    particle1.velocity = Point3F(0.0, 0.1, 1.0);
+    particle2.velocity = Point3F(0.0, -0.1, 1.0);
+    particle3.velocity = Point3F(-0.1, -0.1, 1.0);
+    particle4.velocity = Point3F(0.1, 0.1, 1.0);
     particle1.neighbours = {1, 2, 3};
     particle2.neighbours = {0, 2, 3};
     particle3.neighbours = {0, 1, 3};
@@ -531,21 +531,21 @@ void ForcesTestSuite::externalForcesForThreeNeighbours()
 
 void ForcesTestSuite::externalForcesForFiveNeighbours()
 {
-    Particle particle1(SPHAlgorithms::Point3F(3.0, 3.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3F(3.0, 3.02, 1.0), 0.01);
-    Particle particle3(SPHAlgorithms::Point3F(3.02, 3.0, 1.0), 0.01);
-    Particle particle4(SPHAlgorithms::Point3F(3.02, 3.02, 1.0), 0.01);
-    Particle particle5(SPHAlgorithms::Point3F(3.01, 3.01, 1.0), 0.01);
+    Particle particle1(Point3F(3.0, 3.0, 1.0), 0.01);
+    Particle particle2(Point3F(3.0, 3.02, 1.0), 0.01);
+    Particle particle3(Point3F(3.02, 3.0, 1.0), 0.01);
+    Particle particle4(Point3F(3.02, 3.02, 1.0), 0.01);
+    Particle particle5(Point3F(3.01, 3.01, 1.0), 0.01);
     particle1.neighbours = {1, 2, 3, 4};
     particle2.neighbours = {0, 2, 3, 4};
     particle3.neighbours = {0, 1, 3, 4};
     particle4.neighbours = {0, 1, 2, 4};
     particle5.neighbours = {0, 1, 2, 3};
 
-    particle1.velocity = SPHAlgorithms::Point3F(0.0, 0.1, 1.0);
-    particle2.velocity = SPHAlgorithms::Point3F(0.0, -0.1, 1.0);
-    particle3.velocity = SPHAlgorithms::Point3F(-0.1, -0.1, 1.0);
-    particle4.velocity = SPHAlgorithms::Point3F(0.1, 0.1, 1.0);
+    particle1.velocity = Point3F(0.0, 0.1, 1.0);
+    particle2.velocity = Point3F(0.0, -0.1, 1.0);
+    particle3.velocity = Point3F(-0.1, -0.1, 1.0);
+    particle4.velocity = Point3F(0.1, 0.1, 1.0);
 
     ParticleVect particleVect = {particle1, particle2, particle3, particle4, particle5};
 
@@ -589,10 +589,10 @@ void ForcesTestSuite::externalForcesForFiveNeighbours()
 
 void ForcesTestSuite::allForcesForOneNeighbour()
 {
-    Particle particle1(SPHAlgorithms::Point3F(3.0, 3.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3F(3.0, 3.01, 1.0), 0.01);
-    particle1.velocity = SPHAlgorithms::Point3F(0.0, 0.1, 1.0);
-    particle2.velocity = SPHAlgorithms::Point3F(0.0, -0.1, 1.0);
+    Particle particle1(Point3F(3.0, 3.0, 1.0), 0.01);
+    Particle particle2(Point3F(3.0, 3.01, 1.0), 0.01);
+    particle1.velocity = Point3F(0.0, 0.1, 1.0);
+    particle2.velocity = Point3F(0.0, -0.1, 1.0);
     particle1.neighbours = {1};
     particle2.neighbours = {0};
 
@@ -614,12 +614,12 @@ void ForcesTestSuite::allForcesForOneNeighbour()
 
 void ForcesTestSuite::allForcesForTwoNeighbours()
 {
-    Particle particle1(SPHAlgorithms::Point3F(3.0, 3.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3F(3.0, 3.01, 1.0), 0.01);
-    Particle particle3(SPHAlgorithms::Point3F(3.005, 3.005, 1.0), 0.01);
-    particle1.velocity = SPHAlgorithms::Point3F(0.0, 0.1, 1.0);
-    particle2.velocity = SPHAlgorithms::Point3F(0.0, -0.1, 1.0);
-    particle3.velocity = SPHAlgorithms::Point3F(-0.1, -0.1, 1.0);
+    Particle particle1(Point3F(3.0, 3.0, 1.0), 0.01);
+    Particle particle2(Point3F(3.0, 3.01, 1.0), 0.01);
+    Particle particle3(Point3F(3.005, 3.005, 1.0), 0.01);
+    particle1.velocity = Point3F(0.0, 0.1, 1.0);
+    particle2.velocity = Point3F(0.0, -0.1, 1.0);
+    particle3.velocity = Point3F(-0.1, -0.1, 1.0);
     particle1.neighbours = {1, 2};
     particle2.neighbours = {0, 2};
     particle3.neighbours = {0, 1};
@@ -645,14 +645,14 @@ void ForcesTestSuite::allForcesForTwoNeighbours()
 
 void ForcesTestSuite::allForcesForThreeNeighbours()
 {
-    Particle particle1(SPHAlgorithms::Point3F(3.0, 3.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3F(3.0, 3.01, 1.0), 0.01);
-    Particle particle3(SPHAlgorithms::Point3F(3.005, 3.005, 1.0), 0.01);
-    Particle particle4(SPHAlgorithms::Point3F(2.995, 2.996, 1.0), 0.01);
-    particle1.velocity = SPHAlgorithms::Point3F(0.0, 0.1, 1.0);
-    particle2.velocity = SPHAlgorithms::Point3F(0.0, -0.1, 1.0);
-    particle3.velocity = SPHAlgorithms::Point3F(-0.1, -0.1, 1.0);
-    particle4.velocity = SPHAlgorithms::Point3F(0.1, 0.1, 1.0);
+    Particle particle1(Point3F(3.0, 3.0, 1.0), 0.01);
+    Particle particle2(Point3F(3.0, 3.01, 1.0), 0.01);
+    Particle particle3(Point3F(3.005, 3.005, 1.0), 0.01);
+    Particle particle4(Point3F(2.995, 2.996, 1.0), 0.01);
+    particle1.velocity = Point3F(0.0, 0.1, 1.0);
+    particle2.velocity = Point3F(0.0, -0.1, 1.0);
+    particle3.velocity = Point3F(-0.1, -0.1, 1.0);
+    particle4.velocity = Point3F(0.1, 0.1, 1.0);
     particle1.neighbours = {1, 2, 3};
     particle2.neighbours = {0, 2, 3};
     particle3.neighbours = {0, 1, 3};

--- a/sph/test/src/ForcesTestSuite.cpp
+++ b/sph/test/src/ForcesTestSuite.cpp
@@ -28,18 +28,18 @@ static void initGeneralParticles()
 
     for (size_t i = 0; i < numberOfParticles; ++i)
     {
-        generalParticleVect[i] = Particle(SPHAlgorithms::Point3D(0.5 + 0.01 * i, 0.5 + 0.01 * i, 0.5 + 0.01 * i), 0.01);
+        generalParticleVect[i] = Particle(SPHAlgorithms::Point3F(0.5f + 0.01f * i, 0.5f + 0.01f * i, 0.5f + 0.01f * i), 0.01f);
         generalParticleVect[i].mass = Config::WaterParticleMass;
         generalParticleVect[i].supportRadius = Config::WaterSupportRadius;
     }
 
-    generalParticleVect[0].velocity = SPHAlgorithms::Point3D(1.0, 1.0, 1.0);
-    generalParticleVect[1].velocity = SPHAlgorithms::Point3D(0.5, 0.5, 0.5);
-    generalParticleVect[2].velocity = SPHAlgorithms::Point3D(0.01, 0.01, 0.01);
-    generalParticleVect[3].velocity = SPHAlgorithms::Point3D(-0.5, -0.5, -0.5);
-    generalParticleVect[4].velocity = SPHAlgorithms::Point3D(-1.0, -1.0, -1.0);
+    generalParticleVect[0].velocity = SPHAlgorithms::Point3F(1.0, 1.0, 1.0);
+    generalParticleVect[1].velocity = SPHAlgorithms::Point3F(0.5, 0.5, 0.5);
+    generalParticleVect[2].velocity = SPHAlgorithms::Point3F(0.01, 0.01, 0.01);
+    generalParticleVect[3].velocity = SPHAlgorithms::Point3F(-0.5, -0.5, -0.5);
+    generalParticleVect[4].velocity = SPHAlgorithms::Point3F(-1.0, -1.0, -1.0);
 
-    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3D(0.0, 0.0, 0.0), 1.0, 1.0, 1.0));
+    SPHAlgorithms::Volume volume(SPHAlgorithms::Cuboid(SPHAlgorithms::Point3F(0.0, 0.0, 0.0), 1.0, 1.0, 1.0));
     SPHAlgorithms::NeighboursSearch3D<ParticleVect> searcher(volume, Config::WaterSupportRadius, 0.001);
     searcher.search(generalParticleVect);
 }
@@ -173,8 +173,8 @@ void ForcesTestSuite::externalForcesForFourNeighbours()
 
 void ForcesTestSuite::densityForOneNeighbour()
 {
-    Particle particle1(SPHAlgorithms::Point3D(3.0, 3.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3D(3.0, 3.01, 1.0), 0.01);
+    Particle particle1(SPHAlgorithms::Point3F(3.0, 3.0, 1.0), 0.01);
+    Particle particle2(SPHAlgorithms::Point3F(3.0, 3.01, 1.0), 0.01);
     particle1.neighbours = {1};
     particle2.neighbours = {0};
 
@@ -188,9 +188,9 @@ void ForcesTestSuite::densityForOneNeighbour()
 
 void ForcesTestSuite::densityForTwoNeighbours()
 {
-    Particle particle1(SPHAlgorithms::Point3D(3.0, 3.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3D(3.0, 3.01, 1.0), 0.01);
-    Particle particle3(SPHAlgorithms::Point3D(3.005, 3.005, 1.0), 0.01);
+    Particle particle1(SPHAlgorithms::Point3F(3.0, 3.0, 1.0), 0.01);
+    Particle particle2(SPHAlgorithms::Point3F(3.0, 3.01, 1.0), 0.01);
+    Particle particle3(SPHAlgorithms::Point3F(3.005, 3.005, 1.0), 0.01);
     particle1.neighbours = {1, 2};
     particle2.neighbours = {0, 2};
     particle3.neighbours = {0, 1};
@@ -206,10 +206,10 @@ void ForcesTestSuite::densityForTwoNeighbours()
 
 void ForcesTestSuite::densityForThreeNeighbours()
 {
-    Particle particle1(SPHAlgorithms::Point3D(3.0, 3.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3D(3.0, 3.01, 1.0), 0.01);
-    Particle particle3(SPHAlgorithms::Point3D(3.005, 3.005, 1.0), 0.01);
-    Particle particle4(SPHAlgorithms::Point3D(2.995, 2.996, 1.0), 0.01);
+    Particle particle1(SPHAlgorithms::Point3F(3.0, 3.0, 1.0), 0.01);
+    Particle particle2(SPHAlgorithms::Point3F(3.0, 3.01, 1.0), 0.01);
+    Particle particle3(SPHAlgorithms::Point3F(3.005, 3.005, 1.0), 0.01);
+    Particle particle4(SPHAlgorithms::Point3F(2.995, 2.996, 1.0), 0.01);
     particle1.neighbours = {1, 2, 3};
     particle2.neighbours = {0, 2, 3};
     particle3.neighbours = {0, 1, 3};
@@ -227,8 +227,8 @@ void ForcesTestSuite::densityForThreeNeighbours()
 
 void ForcesTestSuite::pressureForOneNeighbour()
 {
-    Particle particle1(SPHAlgorithms::Point3D(0.0, 0.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3D(0.0, 0.01, 1.0), 0.01);
+    Particle particle1(SPHAlgorithms::Point3F(0.0, 0.0, 1.0), 0.01);
+    Particle particle2(SPHAlgorithms::Point3F(0.0, 0.01, 1.0), 0.01);
     particle1.neighbours = {1};
     particle2.neighbours = {0};
 
@@ -243,9 +243,9 @@ void ForcesTestSuite::pressureForOneNeighbour()
 
 void ForcesTestSuite::pressureForTwoNeighbours()
 {
-    Particle particle1(SPHAlgorithms::Point3D(3.0, 3.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3D(3.0, 3.01, 1.0), 0.01);
-    Particle particle3(SPHAlgorithms::Point3D(3.005, 3.005, 1.0), 0.01);
+    Particle particle1(SPHAlgorithms::Point3F(3.0, 3.0, 1.0), 0.01);
+    Particle particle2(SPHAlgorithms::Point3F(3.0, 3.01, 1.0), 0.01);
+    Particle particle3(SPHAlgorithms::Point3F(3.005, 3.005, 1.0), 0.01);
     particle1.neighbours = {1, 2};
     particle2.neighbours = {0, 2};
     particle3.neighbours = {0, 1};
@@ -262,10 +262,10 @@ void ForcesTestSuite::pressureForTwoNeighbours()
 
 void ForcesTestSuite::pressureForThreeNeighbours()
 {
-    Particle particle1(SPHAlgorithms::Point3D(3.0, 3.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3D(3.0, 3.01, 1.0), 0.01);
-    Particle particle3(SPHAlgorithms::Point3D(3.005, 3.005, 1.0), 0.01);
-    Particle particle4(SPHAlgorithms::Point3D(2.995, 2.996, 1.0), 0.01);
+    Particle particle1(SPHAlgorithms::Point3F(3.0, 3.0, 1.0), 0.01);
+    Particle particle2(SPHAlgorithms::Point3F(3.0, 3.01, 1.0), 0.01);
+    Particle particle3(SPHAlgorithms::Point3F(3.005, 3.005, 1.0), 0.01);
+    Particle particle4(SPHAlgorithms::Point3F(2.995, 2.996, 1.0), 0.01);
     particle1.neighbours = {1, 2, 3};
     particle2.neighbours = {0, 2, 3};
     particle3.neighbours = {0, 1, 3};
@@ -284,10 +284,10 @@ void ForcesTestSuite::pressureForThreeNeighbours()
 
 void ForcesTestSuite::internalForcesForOneNeighbour()
 {
-    Particle particle1(SPHAlgorithms::Point3D(0.0, 0.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3D(0.0, 0.01, 1.0), 0.01);
-    particle1.velocity = SPHAlgorithms::Point3D(0.1, 0.1, 1.0);
-    particle2.velocity = SPHAlgorithms::Point3D(-0.1, -0.1, 1.0);
+    Particle particle1(SPHAlgorithms::Point3F(0.0, 0.0, 1.0), 0.01);
+    Particle particle2(SPHAlgorithms::Point3F(0.0, 0.01, 1.0), 0.01);
+    particle1.velocity = SPHAlgorithms::Point3F(0.1, 0.1, 1.0);
+    particle2.velocity = SPHAlgorithms::Point3F(-0.1, -0.1, 1.0);
     particle1.neighbours = {1};
     particle2.neighbours = {0};
 
@@ -321,12 +321,12 @@ void ForcesTestSuite::internalForcesForOneNeighbour()
 
 void ForcesTestSuite::internalForcesForTwoNeighbours()
 {
-    Particle particle1(SPHAlgorithms::Point3D(3.0, 3.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3D(3.0, 3.01, 1.0), 0.01);
-    Particle particle3(SPHAlgorithms::Point3D(3.005, 3.005, 1.0), 0.01);
-    particle1.velocity = SPHAlgorithms::Point3D(0.1, 0.1, 1.0);
-    particle2.velocity = SPHAlgorithms::Point3D(-0.1, -0.1, 1.0);
-    particle3.velocity = SPHAlgorithms::Point3D(0.1, -0.1, 1.0);
+    Particle particle1(SPHAlgorithms::Point3F(3.0, 3.0, 1.0), 0.01);
+    Particle particle2(SPHAlgorithms::Point3F(3.0, 3.01, 1.0), 0.01);
+    Particle particle3(SPHAlgorithms::Point3F(3.005, 3.005, 1.0), 0.01);
+    particle1.velocity = SPHAlgorithms::Point3F(0.1, 0.1, 1.0);
+    particle2.velocity = SPHAlgorithms::Point3F(-0.1, -0.1, 1.0);
+    particle3.velocity = SPHAlgorithms::Point3F(0.1, -0.1, 1.0);
     particle1.neighbours = {1, 2};
     particle2.neighbours = {0, 2};
     particle3.neighbours = {0, 1};
@@ -361,14 +361,14 @@ void ForcesTestSuite::internalForcesForTwoNeighbours()
 
 void ForcesTestSuite::internalForcesForThreeNeighbours()
 {
-    Particle particle1(SPHAlgorithms::Point3D(3.0, 3.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3D(3.0, 3.01, 1.0), 0.01);
-    Particle particle3(SPHAlgorithms::Point3D(3.005, 3.005, 1.0), 0.01);
-    Particle particle4(SPHAlgorithms::Point3D(2.995, 2.996, 1.0), 0.01);
-    particle1.velocity = SPHAlgorithms::Point3D(0.0, 0.1, 1.0);
-    particle2.velocity = SPHAlgorithms::Point3D(0.0, -0.1, 1.0);
-    particle3.velocity = SPHAlgorithms::Point3D(-0.1, -0.1, 1.0);
-    particle3.velocity = SPHAlgorithms::Point3D(0.1, 0.1, 1.0);
+    Particle particle1(SPHAlgorithms::Point3F(3.0, 3.0, 1.0), 0.01);
+    Particle particle2(SPHAlgorithms::Point3F(3.0, 3.01, 1.0), 0.01);
+    Particle particle3(SPHAlgorithms::Point3F(3.005, 3.005, 1.0), 0.01);
+    Particle particle4(SPHAlgorithms::Point3F(2.995, 2.996, 1.0), 0.01);
+    particle1.velocity = SPHAlgorithms::Point3F(0.0, 0.1, 1.0);
+    particle2.velocity = SPHAlgorithms::Point3F(0.0, -0.1, 1.0);
+    particle3.velocity = SPHAlgorithms::Point3F(-0.1, -0.1, 1.0);
+    particle3.velocity = SPHAlgorithms::Point3F(0.1, 0.1, 1.0);
     particle1.neighbours = {1, 2, 3};
     particle2.neighbours = {0, 2, 3};
     particle3.neighbours = {0, 1, 3};
@@ -410,10 +410,10 @@ void ForcesTestSuite::internalForcesForThreeNeighbours()
 
 void ForcesTestSuite::externalForcesForOneNeighbour()
 {
-    Particle particle1(SPHAlgorithms::Point3D(0.0, 0.0, 0.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3D(0.0, 0.01, 0.0), 0.01);
-    particle1.velocity = SPHAlgorithms::Point3D(0.1, 0.1, 0.1);
-    particle2.velocity = SPHAlgorithms::Point3D(-0.1, -0.1, -0.1);
+    Particle particle1(SPHAlgorithms::Point3F(0.0, 0.0, 0.0), 0.01);
+    Particle particle2(SPHAlgorithms::Point3F(0.0, 0.01, 0.0), 0.01);
+    particle1.velocity = SPHAlgorithms::Point3F(0.1, 0.1, 0.1);
+    particle2.velocity = SPHAlgorithms::Point3F(-0.1, -0.1, -0.1);
     particle1.neighbours = {1};
     particle2.neighbours = {0};
 
@@ -442,12 +442,12 @@ void ForcesTestSuite::externalForcesForOneNeighbour()
 
 void ForcesTestSuite::externalForcesForTwoNeighbours()
 {
-    Particle particle1(SPHAlgorithms::Point3D(3.0, 3.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3D(3.0, 3.01, 1.0), 0.01);
-    Particle particle3(SPHAlgorithms::Point3D(3.005, 3.005, 1.0), 0.01);
-    particle1.velocity = SPHAlgorithms::Point3D(0.1, 0.1, 1.0);
-    particle2.velocity = SPHAlgorithms::Point3D(-0.1, -0.1, 1.0);
-    particle3.velocity = SPHAlgorithms::Point3D(0.1, -0.1, 1.0);
+    Particle particle1(SPHAlgorithms::Point3F(3.0, 3.0, 1.0), 0.01);
+    Particle particle2(SPHAlgorithms::Point3F(3.0, 3.01, 1.0), 0.01);
+    Particle particle3(SPHAlgorithms::Point3F(3.005, 3.005, 1.0), 0.01);
+    particle1.velocity = SPHAlgorithms::Point3F(0.1, 0.1, 1.0);
+    particle2.velocity = SPHAlgorithms::Point3F(-0.1, -0.1, 1.0);
+    particle3.velocity = SPHAlgorithms::Point3F(0.1, -0.1, 1.0);
     particle1.neighbours = {1, 2};
     particle2.neighbours = {0, 2};
     particle3.neighbours = {0, 1};
@@ -482,14 +482,14 @@ void ForcesTestSuite::externalForcesForTwoNeighbours()
 
 void ForcesTestSuite::externalForcesForThreeNeighbours()
 {
-    Particle particle1(SPHAlgorithms::Point3D(3.0, 3.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3D(3.0, 3.01, 1.0), 0.01);
-    Particle particle3(SPHAlgorithms::Point3D(3.005, 3.005, 1.0), 0.01);
-    Particle particle4(SPHAlgorithms::Point3D(2.995, 2.996, 1.0), 0.01);
-    particle1.velocity = SPHAlgorithms::Point3D(0.0, 0.1, 1.0);
-    particle2.velocity = SPHAlgorithms::Point3D(0.0, -0.1, 1.0);
-    particle3.velocity = SPHAlgorithms::Point3D(-0.1, -0.1, 1.0);
-    particle4.velocity = SPHAlgorithms::Point3D(0.1, 0.1, 1.0);
+    Particle particle1(SPHAlgorithms::Point3F(3.0, 3.0, 1.0), 0.01);
+    Particle particle2(SPHAlgorithms::Point3F(3.0, 3.01, 1.0), 0.01);
+    Particle particle3(SPHAlgorithms::Point3F(3.005, 3.005, 1.0), 0.01);
+    Particle particle4(SPHAlgorithms::Point3F(2.995, 2.996, 1.0), 0.01);
+    particle1.velocity = SPHAlgorithms::Point3F(0.0, 0.1, 1.0);
+    particle2.velocity = SPHAlgorithms::Point3F(0.0, -0.1, 1.0);
+    particle3.velocity = SPHAlgorithms::Point3F(-0.1, -0.1, 1.0);
+    particle4.velocity = SPHAlgorithms::Point3F(0.1, 0.1, 1.0);
     particle1.neighbours = {1, 2, 3};
     particle2.neighbours = {0, 2, 3};
     particle3.neighbours = {0, 1, 3};
@@ -531,21 +531,21 @@ void ForcesTestSuite::externalForcesForThreeNeighbours()
 
 void ForcesTestSuite::externalForcesForFiveNeighbours()
 {
-    Particle particle1(SPHAlgorithms::Point3D(3.0, 3.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3D(3.0, 3.02, 1.0), 0.01);
-    Particle particle3(SPHAlgorithms::Point3D(3.02, 3.0, 1.0), 0.01);
-    Particle particle4(SPHAlgorithms::Point3D(3.02, 3.02, 1.0), 0.01);
-    Particle particle5(SPHAlgorithms::Point3D(3.01, 3.01, 1.0), 0.01);
+    Particle particle1(SPHAlgorithms::Point3F(3.0, 3.0, 1.0), 0.01);
+    Particle particle2(SPHAlgorithms::Point3F(3.0, 3.02, 1.0), 0.01);
+    Particle particle3(SPHAlgorithms::Point3F(3.02, 3.0, 1.0), 0.01);
+    Particle particle4(SPHAlgorithms::Point3F(3.02, 3.02, 1.0), 0.01);
+    Particle particle5(SPHAlgorithms::Point3F(3.01, 3.01, 1.0), 0.01);
     particle1.neighbours = {1, 2, 3, 4};
     particle2.neighbours = {0, 2, 3, 4};
     particle3.neighbours = {0, 1, 3, 4};
     particle4.neighbours = {0, 1, 2, 4};
     particle5.neighbours = {0, 1, 2, 3};
 
-    particle1.velocity = SPHAlgorithms::Point3D(0.0, 0.1, 1.0);
-    particle2.velocity = SPHAlgorithms::Point3D(0.0, -0.1, 1.0);
-    particle3.velocity = SPHAlgorithms::Point3D(-0.1, -0.1, 1.0);
-    particle4.velocity = SPHAlgorithms::Point3D(0.1, 0.1, 1.0);
+    particle1.velocity = SPHAlgorithms::Point3F(0.0, 0.1, 1.0);
+    particle2.velocity = SPHAlgorithms::Point3F(0.0, -0.1, 1.0);
+    particle3.velocity = SPHAlgorithms::Point3F(-0.1, -0.1, 1.0);
+    particle4.velocity = SPHAlgorithms::Point3F(0.1, 0.1, 1.0);
 
     ParticleVect particleVect = {particle1, particle2, particle3, particle4, particle5};
 
@@ -589,10 +589,10 @@ void ForcesTestSuite::externalForcesForFiveNeighbours()
 
 void ForcesTestSuite::allForcesForOneNeighbour()
 {
-    Particle particle1(SPHAlgorithms::Point3D(3.0, 3.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3D(3.0, 3.01, 1.0), 0.01);
-    particle1.velocity = SPHAlgorithms::Point3D(0.0, 0.1, 1.0);
-    particle2.velocity = SPHAlgorithms::Point3D(0.0, -0.1, 1.0);
+    Particle particle1(SPHAlgorithms::Point3F(3.0, 3.0, 1.0), 0.01);
+    Particle particle2(SPHAlgorithms::Point3F(3.0, 3.01, 1.0), 0.01);
+    particle1.velocity = SPHAlgorithms::Point3F(0.0, 0.1, 1.0);
+    particle2.velocity = SPHAlgorithms::Point3F(0.0, -0.1, 1.0);
     particle1.neighbours = {1};
     particle2.neighbours = {0};
 
@@ -614,12 +614,12 @@ void ForcesTestSuite::allForcesForOneNeighbour()
 
 void ForcesTestSuite::allForcesForTwoNeighbours()
 {
-    Particle particle1(SPHAlgorithms::Point3D(3.0, 3.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3D(3.0, 3.01, 1.0), 0.01);
-    Particle particle3(SPHAlgorithms::Point3D(3.005, 3.005, 1.0), 0.01);
-    particle1.velocity = SPHAlgorithms::Point3D(0.0, 0.1, 1.0);
-    particle2.velocity = SPHAlgorithms::Point3D(0.0, -0.1, 1.0);
-    particle3.velocity = SPHAlgorithms::Point3D(-0.1, -0.1, 1.0);
+    Particle particle1(SPHAlgorithms::Point3F(3.0, 3.0, 1.0), 0.01);
+    Particle particle2(SPHAlgorithms::Point3F(3.0, 3.01, 1.0), 0.01);
+    Particle particle3(SPHAlgorithms::Point3F(3.005, 3.005, 1.0), 0.01);
+    particle1.velocity = SPHAlgorithms::Point3F(0.0, 0.1, 1.0);
+    particle2.velocity = SPHAlgorithms::Point3F(0.0, -0.1, 1.0);
+    particle3.velocity = SPHAlgorithms::Point3F(-0.1, -0.1, 1.0);
     particle1.neighbours = {1, 2};
     particle2.neighbours = {0, 2};
     particle3.neighbours = {0, 1};
@@ -645,14 +645,14 @@ void ForcesTestSuite::allForcesForTwoNeighbours()
 
 void ForcesTestSuite::allForcesForThreeNeighbours()
 {
-    Particle particle1(SPHAlgorithms::Point3D(3.0, 3.0, 1.0), 0.01);
-    Particle particle2(SPHAlgorithms::Point3D(3.0, 3.01, 1.0), 0.01);
-    Particle particle3(SPHAlgorithms::Point3D(3.005, 3.005, 1.0), 0.01);
-    Particle particle4(SPHAlgorithms::Point3D(2.995, 2.996, 1.0), 0.01);
-    particle1.velocity = SPHAlgorithms::Point3D(0.0, 0.1, 1.0);
-    particle2.velocity = SPHAlgorithms::Point3D(0.0, -0.1, 1.0);
-    particle3.velocity = SPHAlgorithms::Point3D(-0.1, -0.1, 1.0);
-    particle4.velocity = SPHAlgorithms::Point3D(0.1, 0.1, 1.0);
+    Particle particle1(SPHAlgorithms::Point3F(3.0, 3.0, 1.0), 0.01);
+    Particle particle2(SPHAlgorithms::Point3F(3.0, 3.01, 1.0), 0.01);
+    Particle particle3(SPHAlgorithms::Point3F(3.005, 3.005, 1.0), 0.01);
+    Particle particle4(SPHAlgorithms::Point3F(2.995, 2.996, 1.0), 0.01);
+    particle1.velocity = SPHAlgorithms::Point3F(0.0, 0.1, 1.0);
+    particle2.velocity = SPHAlgorithms::Point3F(0.0, -0.1, 1.0);
+    particle3.velocity = SPHAlgorithms::Point3F(-0.1, -0.1, 1.0);
+    particle4.velocity = SPHAlgorithms::Point3F(0.1, 0.1, 1.0);
     particle1.neighbours = {1, 2, 3};
     particle2.neighbours = {0, 2, 3};
     particle3.neighbours = {0, 1, 3};

--- a/sph/test/src/IntegratorTestSuite.cpp
+++ b/sph/test/src/IntegratorTestSuite.cpp
@@ -17,10 +17,10 @@ namespace TestEnvironment
 
 void IntegratorTestSuite::oneParticleWithZeroVelocity()
 {
-    ParticleVect particles = {Particle(SPHAlgorithms::Point3D(0., 1., 1.), 0.1)};
+    ParticleVect particles = {Particle(SPHAlgorithms::Point3F(0., 1., 1.), 0.1)};
     particles[0].density = 0.5;
-    particles[0].fTotal = SPHAlgorithms::Point3D(0.25, 0.25, 0.25);
-    particles[0].acceleration = SPHAlgorithms::Point3D(0.1, 0.1, 0.1);
+    particles[0].fTotal = SPHAlgorithms::Point3F(0.25, 0.25, 0.25);
+    particles[0].acceleration = SPHAlgorithms::Point3F(0.1, 0.1, 0.1);
 
     Integrator::integrate(0.01, particles);
 
@@ -34,9 +34,9 @@ void IntegratorTestSuite::oneParticleWithZeroVelocity()
 
 void IntegratorTestSuite::oneParticleWithZeroDensity()
 {
-    ParticleVect particles = {Particle(SPHAlgorithms::Point3D(0., 1., 1.0), 0.1)};
-    particles[0].fTotal = SPHAlgorithms::Point3D(0.25, 0.25, 0.25);
-    particles[0].acceleration = SPHAlgorithms::Point3D(0.1, 0.1, 0.1);
+    ParticleVect particles = {Particle(SPHAlgorithms::Point3F(0., 1., 1.0), 0.1)};
+    particles[0].fTotal = SPHAlgorithms::Point3F(0.25, 0.25, 0.25);
+    particles[0].acceleration = SPHAlgorithms::Point3F(0.1, 0.1, 0.1);
 
     Integrator::integrate(0.01, particles);
 

--- a/sph/test/src/IntegratorTestSuite.cpp
+++ b/sph/test/src/IntegratorTestSuite.cpp
@@ -17,10 +17,10 @@ namespace TestEnvironment
 
 void IntegratorTestSuite::oneParticleWithZeroVelocity()
 {
-    ParticleVect particles = {Particle(SPHAlgorithms::Point3F(0., 1., 1.), 0.1)};
+    ParticleVect particles = {Particle(Point3F(0., 1., 1.), 0.1)};
     particles[0].density = 0.5;
-    particles[0].fTotal = SPHAlgorithms::Point3F(0.25, 0.25, 0.25);
-    particles[0].acceleration = SPHAlgorithms::Point3F(0.1, 0.1, 0.1);
+    particles[0].fTotal = Point3F(0.25, 0.25, 0.25);
+    particles[0].acceleration = Point3F(0.1, 0.1, 0.1);
 
     Integrator::integrate(0.01, particles);
 
@@ -34,9 +34,9 @@ void IntegratorTestSuite::oneParticleWithZeroVelocity()
 
 void IntegratorTestSuite::oneParticleWithZeroDensity()
 {
-    ParticleVect particles = {Particle(SPHAlgorithms::Point3F(0., 1., 1.0), 0.1)};
-    particles[0].fTotal = SPHAlgorithms::Point3F(0.25, 0.25, 0.25);
-    particles[0].acceleration = SPHAlgorithms::Point3F(0.1, 0.1, 0.1);
+    ParticleVect particles = {Particle(Point3F(0., 1., 1.0), 0.1)};
+    particles[0].fTotal = Point3F(0.25, 0.25, 0.25);
+    particles[0].acceleration = Point3F(0.1, 0.1, 0.1);
 
     Integrator::integrate(0.01, particles);
 

--- a/sph/test/src/ParticleTestSuite.cpp
+++ b/sph/test/src/ParticleTestSuite.cpp
@@ -22,6 +22,9 @@ void ParticleTestSuite::particleIsValid()
     EXPECT_DOUBLE_EQ(5.0, particle.position.x);
     EXPECT_DOUBLE_EQ(-6.0, particle.position.y);
     EXPECT_DOUBLE_EQ(1.0, particle.position.z);
+    EXPECT_DOUBLE_EQ(0.0, particle.colour.x);
+    EXPECT_DOUBLE_EQ(0.0, particle.colour.y);
+    EXPECT_DOUBLE_EQ(0.0, particle.colour.z);
     EXPECT_DOUBLE_EQ(0.1, particle.radius);
     EXPECT_DOUBLE_EQ(0.0, particle.velocity.x);
     EXPECT_DOUBLE_EQ(0.0, particle.velocity.y);

--- a/sph/test/src/ParticleTestSuite.cpp
+++ b/sph/test/src/ParticleTestSuite.cpp
@@ -17,7 +17,7 @@ namespace TestEnvironment
 
 void ParticleTestSuite::particleIsValid()
 {
-    Particle particle(SPHAlgorithms::Point3D(5.0, -6.0, 1.0), 0.1);
+    Particle particle(SPHAlgorithms::Point3F(5.0, -6.0, 1.0), 0.1);
 
     EXPECT_DOUBLE_EQ(5.0, particle.position.x);
     EXPECT_DOUBLE_EQ(-6.0, particle.position.y);

--- a/sph/test/src/ParticleTestSuite.cpp
+++ b/sph/test/src/ParticleTestSuite.cpp
@@ -17,7 +17,7 @@ namespace TestEnvironment
 
 void ParticleTestSuite::particleIsValid()
 {
-    Particle particle(SPHAlgorithms::Point3F(5.0, -6.0, 1.0), 0.1);
+    Particle particle(Point3F(5.0, -6.0, 1.0), 0.1);
 
     EXPECT_DOUBLE_EQ(5.0, particle.position.x);
     EXPECT_DOUBLE_EQ(-6.0, particle.position.y);


### PR DESCRIPTION
# What does this PR do?
- Optimise drawing of particles - do copy particles to a sep vector
- Remove `SPHAlgorithms` namespace
- Introduce 1 floating-point time `FLOAT` to easily switch from `double` to `float` if needed

## Issue reference
Fixes #17

## Explanation
The main intent of this PR is to avoid copying from `particles` array to the one created specifically for drawing. This will reduce memory usage and speed up the app.

## How to get?
`git clone --recursive -b float git@github.com:aartiukh/sph.git`
