### PR TITLE
Fix venv dir in gitignore for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@
 *.app
 
 # Python venv
-venv/*
+venv/
 __pycache__/
 
 build/*


### PR DESCRIPTION
# What does this PR do?
Fixes venv dir path in gitignore to work on Windows

## Issue reference
-

## Explanation
To ignore venv dir containing local python env on Windows

## How to get?
`git clone --recursive -b feature/blabla git@github.com:aartiukh/sph.git`
