### PR TITLE
Bump Gtest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ C++ implementation of Smoothed Particle Hydrodynamics.
 * `cmake -G "Visual Studio 16 2019" -A x64 -DBUILD_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=Release ..`
 * Open generated `sph-sdk.sln` and run `Build Solution` in MSVC 2019 IDE
 
+### Windows MinGW
+
+* `cd build`
+* `cmake -G "MinGW Makefiles"  -DBUILD_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=Release ..`
+* `cmake --build . --config Release -j8`
+
 ### Mac OS
 
 * `cd build`

--- a/algorithms/test/src/NSGridBasedOldTestSuite.cpp
+++ b/algorithms/test/src/NSGridBasedOldTestSuite.cpp
@@ -5,6 +5,7 @@
 #include "NSBruteForceImproved.h"
 #include "NSGridBasedOld.h"
 
+#include <algorithm>
 #include <stdexcept>
 
 #include <gtest/gtest.h>

--- a/algorithms/test/src/NeighbourSearchTestSuite.cpp
+++ b/algorithms/test/src/NeighbourSearchTestSuite.cpp
@@ -7,6 +7,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <memory>
 #include <vector>
 


### PR DESCRIPTION
# What does this PR do?

Bump Gtest to 1.16.0 version

## Explanation

To keep deps up-to-date
